### PR TITLE
Fix class static properties issue.

### DIFF
--- a/src/components/tab/rkTab.js
+++ b/src/components/tab/rkTab.js
@@ -5,8 +5,7 @@ import {
 } from 'react-native';
 
 export class RkTab extends React.Component {
-
-  static name = 'tab';
+  componentName = 'RkTab';
 
   constructor(props) {
     super(props);

--- a/src/styles/typeManager.js
+++ b/src/styles/typeManager.js
@@ -1,21 +1,21 @@
 import {DefaultTypes} from './defaultTypes.js';
 import _ from 'lodash'
 
-export const TypeManager = class {
+export class TypeManager {
   static _userTypes = [];
   static _themedTypes;
   static _themableTypes = {};
 
   static types = (theme) => {
-    if (!this._themedTypes) {
-      this._themedTypes = {};
+    if (!TypeManager._themedTypes) {
+      TypeManager._themedTypes = {};
       _.forOwn(TypeManager._themableTypes, (value, key) => {
-        _.set(this._themedTypes, key, value(theme))
+        _.set(TypeManager._themedTypes, key, value(theme))
       });
 
-      this._themedTypes = _.merge(DefaultTypes(theme), this._themedTypes, TypeManager._userTypes);
+      TypeManager._themedTypes = _.merge(DefaultTypes(theme), TypeManager._themedTypes, TypeManager._userTypes);
     }
-    return this._themedTypes;
+    return TypeManager._themedTypes;
   };
 
   static setType = (element, name, value) => {
@@ -29,6 +29,6 @@ export const TypeManager = class {
   };
 
   static invalidateTypes = () => {
-    this._themedTypes = undefined;
+    TypeManager._themedTypes = undefined;
   }
 };


### PR DESCRIPTION
Just fixed some issues.

**rkTab.js**
Issue: The "name" is a read only property of a function.

**typeManager.js**
Issue: Can not use "this" in the class static function.

The convert result by default react-native config.
`this` in the original class static function, converted to `_this`, which points to global context `this`.
```javascript
'use strict';

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.TypeManager = undefined;

var _class,
    _temp,
    _this = this;

var _defaultTypes = require('./defaultTypes.js');

var _lodash = require('lodash');

var _lodash2 = babelHelpers.interopRequireDefault(_lodash);

var TypeManager = exports.TypeManager = (_temp = _class = function TypeManager() {
  babelHelpers.classCallCheck(this, TypeManager);
}, _class._userTypes = [], _class._themableTypes = {}, _class.types = function (theme) {
  if (!_this._themedTypes) {
    _this._themedTypes = {};
    _lodash2.default.forOwn(TypeManager._themableTypes, function (value, key) {
      _lodash2.default.set(_this._themedTypes, key, value(theme));
    });

    _this._themedTypes = _lodash2.default.merge((0, _defaultTypes.DefaultTypes)(theme), _this._themedTyp
es, TypeManager._userTypes);
  }
  return _this._themedTypes;
}, _class.setType = function (element, name, value) {
  _lodash2.default.set(TypeManager._userTypes, [[element], [name]], value);
  TypeManager.invalidateTypes();
}, _class.registerTypes = function (element, types) {
  _lodash2.default.set(TypeManager._themableTypes, [element], types);
  TypeManager.invalidateTypes();
}, _class.invalidateTypes = function () {
  _this._themedTypes = undefined;
}, _temp);
```
