### PR TITLE
fix extractNonStyleValue

### DIFF
--- a/src/components/rkComponent.js
+++ b/src/components/rkComponent.js
@@ -53,14 +53,12 @@ export class RkComponent extends React.Component {
    * @returns {object} value of extracted property
    */
   extractNonStyleValue(styles, property) {
-    let val = _.find(styles, (e) => e.hasOwnProperty(property));
-    if (val) {
-      styles.splice(styles.indexOf(val), 1);
-    }
-    else {
-      return val;
-    }
-    return val[property];
+    return styles.reduce((acc, style) => {
+      return Object.keys(style).reduce((obj, key) => {
+        obj[key] = style[key]
+        return obj
+      }, acc)
+    }, {})[property]
   }
 
   _getStyleValue(value) {


### PR DESCRIPTION
-extractNonStyleValue doesn't grab the correct value corresponding to the rkType. It just grabs the first value it finds, which corresponds to the _base value. My fix just grabs the last value that it finds instead of the first one.

ticket #38 