### PR TITLE
fix(rkTextInput): fix non-editable rkTextInput crash on Android

### DIFF
--- a/src/components/textinput/rkTextInput.js
+++ b/src/components/textinput/rkTextInput.js
@@ -141,13 +141,19 @@ export class RkTextInput extends RkComponent {
     }
   };
 
+  static defaultProps = {
+    editable: true
+  };
+
   constructor(props) {
     super(props);
     this.focusInput = this._focusInput.bind(this);
   }
 
   _focusInput() {
-    this.refs.input.focus();
+    if (this.props.editable) {
+      this.refs.input.focus();
+    }
   }
 
   _displayLabel(label, labelStyle) {
@@ -174,7 +180,7 @@ export class RkTextInput extends RkComponent {
       inputStyle,
       ...inputProps
     } = this.props;
-    let {container:boxStyle, input:input, label:labelS} = this.defineStyles();
+    let {container: boxStyle, input: input, label: labelS} = this.defineStyles();
     let placeholderColor = this.extractNonStyleValue(input, 'placeholderTextColor');
     labelStyle = [labelS, labelStyle];
     inputProps.style = [input, inputStyle];


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [+] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [+] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Fix of crash on rkTextInput press when non-editable
[See issue](https://github.com/akveo/react-native-ui-kitten/issues/113)