### PR TITLE
fix(rkModalImg): container with more than 10 items render. Closes #98

### DIFF
--- a/example/screens/ImageScreen.js
+++ b/example/screens/ImageScreen.js
@@ -1,31 +1,30 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import {
   View,
-  StyleSheet,
   ScrollView,
   ListView,
-  Dimensions, Alert
+  Dimensions, Alert,
 } from 'react-native';
 import {
   RkButton,
   RkModalImg,
   RkText,
-  RkStyleSheet
+  RkStyleSheet,
 } from 'react-native-ui-kitten';
 
-import {UtilStyles} from '../style/styles';
 import Icon from 'react-native-vector-icons/FontAwesome';
+import { UtilStyles } from '../style/styles';
 
 export class ImageScreen extends Component {
   static navigationOptions = {
-    title: 'Images'
+    title: 'Images',
   };
 
   constructor(props) {
     super(props);
 
-    let ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1.id !== r2.id});
-    this._images = [
+    const dataSource = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1.id !== r2.id });
+    this.images = [
       require('../img/animal.jpeg'),
       require('../img/bird.jpeg'),
       require('../img/clock.jpg'),
@@ -35,39 +34,56 @@ export class ImageScreen extends Component {
       require('../img/river.jpeg'),
       require('../img/sea.jpg'),
       require('../img/sun.jpg'),
+      require('../img/wood.jpeg'),
+      require('../img/flowers.jpeg'),
+      require('../img/tree.jpeg'),
     ];
     this.state = {
-      ds: ds.cloneWithRows(this._images),
+      ds: dataSource.cloneWithRows(this.images),
     };
 
-    let {width} = Dimensions.get('window');
+    const { width } = Dimensions.get('window');
     this.imgSize = (width - 16) / 3;
   }
 
-  _renderFooter(options) {
+  onRenderCustomHeader(options) {
+    return (
+      <View style={{ justifyContent: 'space-between', alignItems: 'center', flexDirection: 'row' }}>
+        <RkButton rkType='clear' onPress={options.closeImage}>Close</RkButton>
+        <RkButton rkType='clear'>
+          <Icon style={styles.dot} name="circle" />
+          <Icon style={styles.dot} name="circle" />
+          <Icon style={styles.dot} name="circle" />
+        </RkButton>
+      </View>
+    );
+  }
+
+  onRenderCustomFooter() {
     return (
       <View style={{
         justifyContent: 'center',
         alignItems: 'center',
         flexDirection: 'row',
         paddingVertical: 10,
-        paddingHorizontal: 20
-      }}>
-        <View style={{flex: 1, flexDirection: 'row', alignItems: 'center'}}>
-          <RkButton rkType='clear small' onPress={(x) => Alert.alert('I Like it!')}>
-            <Icon name={'heart'} style={styles.buttonIcon}/>
+        paddingHorizontal: 20,
+      }}
+      >
+        <View style={{ flex: 1, flexDirection: 'row', alignItems: 'center' }}>
+          <RkButton rkType='clear small' onPress={() => Alert.alert('I Like it!')}>
+            <Icon name="heart" style={styles.buttonIcon} />
             <RkText rkType='inverse'>18</RkText>
           </RkButton>
         </View>
-        <View style={{flex: 1}}>
+        <View style={{ flex: 1 }}>
           <RkButton rkType='clear small'>
-            <Icon name={'comment-o'} style={styles.buttonIcon}/>
+            <Icon name="comment-o" style={styles.buttonIcon} />
             <RkText rkType='inverse'>2</RkText>
           </RkButton>
         </View>
-        <View style={{flex: 1}}>
+        <View style={{ flex: 1 }}>
           <RkButton rkType='clear small'>
-            <Icon name={'send-o'} style={styles.buttonIcon}/>
+            <Icon name="send-o" style={styles.buttonIcon} />
             <RkText rkType='inverse'>7</RkText>
           </RkButton>
         </View>
@@ -75,20 +91,8 @@ export class ImageScreen extends Component {
     );
   }
 
-  _renderHeader(options) {
-    return (
-      <View style={{justifyContent: 'space-between', alignItems: 'center', flexDirection: 'row'}}>
-        <RkButton rkType='clear' onPress={options.closeImage}>Close</RkButton>
-        <RkButton rkType='clear'>
-          <Icon style={styles.dot} name={'circle'}/>
-          <Icon style={styles.dot} name={'circle'}/>
-          <Icon style={styles.dot} name={'circle'}/>
-        </RkButton>
-      </View>
-    );
-  }
 
-  _renderGallery() {
+  onRenderGallery() {
     return (
       <ListView
         pageSize={3}
@@ -96,72 +100,84 @@ export class ImageScreen extends Component {
           justifyContent: 'flex-start',
           alignItems: 'flex-start',
           flexDirection: 'row',
-          flexWrap: 'wrap'
+          flexWrap: 'wrap',
         }}
         scrollRenderAheadDistance={500}
         dataSource={this.state.ds}
-        renderRow={(rowData, sectionID, rowID) => {
-          return (
-            <RkModalImg
-              style={{width: this.imgSize, height: this.imgSize}}
-              source={this._images}
-              index={rowID}/>
-          )
-        }}
+        renderRow={(rowData, sectionID, rowID) => (
+          <RkModalImg
+            style={{ width: this.imgSize, height: this.imgSize }}
+            source={this.images}
+            index={rowID}
+          />
+        )}
       />
-    )
+    );
   }
 
   render() {
     return (
-      <View style={{flex: 1}}>
-
+      <View style={{ flex: 1 }}>
         <ScrollView
-          automaticallyAdjustContentInsets={true}
-          style={UtilStyles.container}>
-
+          automaticallyAdjustContentInsets
+          style={UtilStyles.container}
+        >
           <View style={[UtilStyles.section, UtilStyles.bordered, styles.imagesContainer]}>
             <RkText style={styles.header} rkType='header'>Basic example</RkText>
-            <View style={[UtilStyles.rowContainer, {paddingLeft: 2}]}>
-              <RkModalImg style={{width: this.imgSize, height: this.imgSize}} source={require('../img/animal.jpeg')}/>
-              <RkModalImg style={{width: this.imgSize, height: this.imgSize}} source={require('../img/clock.jpg')}/>
-              <RkModalImg style={{width: this.imgSize, height: this.imgSize}} source={require('../img/post2.png')}/>
+            <View style={[UtilStyles.rowContainer, { paddingLeft: 2 }]}>
+              <RkModalImg
+                style={{ width: this.imgSize, height: this.imgSize }}
+                source={require('../img/animal.jpeg')}
+              />
+              <RkModalImg
+                style={{ width: this.imgSize, height: this.imgSize }}
+                source={require('../img/clock.jpg')}
+              />
+              <RkModalImg
+                style={{ width: this.imgSize, height: this.imgSize }}
+                source={require('../img/post2.png')}
+              />
             </View>
           </View>
           <View style={[UtilStyles.section, UtilStyles.bordered, styles.imagesContainer]}>
             <RkText style={styles.header} rkType='header'>Custom header and footer</RkText>
-            <View style={[UtilStyles.rowContainer, {paddingLeft: 2}]}>
-              <RkModalImg style={{width: this.imgSize, height: this.imgSize}}
-                          renderHeader={this._renderHeader}
-                          renderFooter={this._renderFooter}
-                          headerContentStyle={{backgroundColor: 'red'}}
-                          source={require('../img/post1.png')}/>
-              <RkModalImg style={{width: this.imgSize, height: this.imgSize}}
-                          renderHeader={this._renderHeader}
-                          renderFooter={this._renderFooter}
-                          source={require('../img/river.jpeg')}/>
-              <RkModalImg style={{width: this.imgSize, height: this.imgSize}}
-                          renderHeader={this._renderHeader}
-                          renderFooter={this._renderFooter}
-                          source={require('../img/post3.png')}/>
-
+            <View style={[UtilStyles.rowContainer, { paddingLeft: 2 }]}>
+              <RkModalImg
+                style={{ width: this.imgSize, height: this.imgSize }}
+                renderHeader={this.onRenderCustomHeader}
+                renderFooter={this.onRenderCustomFooter}
+                headerContentStyle={{ backgroundColor: 'red' }}
+                source={require('../img/post1.png')}
+              />
+              <RkModalImg
+                style={{ width: this.imgSize, height: this.imgSize }}
+                renderHeader={this.onRenderCustomHeader}
+                renderFooter={this.onRenderCustomFooter}
+                source={require('../img/river.jpeg')}
+              />
+              <RkModalImg
+                style={{ width: this.imgSize, height: this.imgSize }}
+                renderHeader={this.onRenderCustomHeader}
+                renderFooter={this.onRenderCustomFooter}
+                source={require('../img/post3.png')}
+              />
             </View>
           </View>
           <View style={[UtilStyles.section, UtilStyles.bordered, styles.imagesContainer]}>
             <RkText style={styles.header} rkType='header'>Gallery Example</RkText>
-            <View style={[UtilStyles.rowContainer, {paddingLeft: 2}]}>
-              {this._renderGallery()}
+            <View style={[UtilStyles.rowContainer, { paddingLeft: 2 }]}>
+              {this.onRenderGallery()}
             </View>
           </View>
         </ScrollView>
       </View>
-    )
+    );
   }
 }
 
 let styles = RkStyleSheet.create(theme => ({
   imagesContainer: {
-    paddingHorizontal: 0
+    paddingHorizontal: 0,
   },
   header: {
     paddingHorizontal: 24,
@@ -170,11 +186,11 @@ let styles = RkStyleSheet.create(theme => ({
     fontSize: 6.5,
     marginLeft: 4,
     marginVertical: 6,
-    color: theme.colors.text.inverse
+    color: theme.colors.text.inverse,
   },
   buttonIcon: {
     marginRight: 7,
     fontSize: 19.7,
-    color: theme.colors.text.inverse
+    color: theme.colors.text.inverse,
   },
 }));

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5725,7 +5725,7 @@ npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
-npm-run-all@^4.1.3:
+npm-run-all@4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.3.tgz#49f15b55a66bb4101664ce270cb18e7103f8f185"
   dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3493,12 +3493,6 @@
         "write": "^0.2.1"
       }
     },
-    "flow-bin": {
-      "version": "0.67.1",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.67.1.tgz",
-      "integrity": "sha512-jZwanQrtgVRDKs3Le3MmD44YTZSzWkpuUeMv4ZckDOuaa2VQ41ttuxqzxErRdTr/ZSs+J1L2SQW6NKO+D4t2Vw==",
-      "dev": true
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/src/components/image/rkModalImg.js
+++ b/src/components/image/rkModalImg.js
@@ -176,6 +176,8 @@ export class RkModalImg extends RkComponent {
       height: undefined,
       index: props.index || 0,
     };
+    this.onRenderHeader = this.onRenderHeader.bind(this);
+    this.onRenderFooter = this.onRenderFooter.bind(this);
     this.onContainerScroll = this.onContainerScroll.bind(this);
   }
 
@@ -199,7 +201,7 @@ export class RkModalImg extends RkComponent {
         initialScrollIndex={index}
         horizontal
         pagingEnabled
-        keyExtractor={(item, srcIndex) => srcIndex}
+        keyExtractor={(item, srcIndex) => srcIndex.toString()}
         onScroll={(event) => this.onContainerScroll(event)}
       />
     );
@@ -207,9 +209,9 @@ export class RkModalImg extends RkComponent {
 
   onRenderItemLayout(item, index) {
     return {
-      index,
       length: this.state.width,
       offset: this.state.width * index,
+      index,
     };
   }
 
@@ -269,12 +271,12 @@ export class RkModalImg extends RkComponent {
     return null;
   }
 
-  onRenderFooter = () => {
+  onRenderFooter() {
     const style = this.styles ? this.styles.footerContent : {};
     return (
       <View style={style} />
     );
-  };
+  }
 
   onImageClicked = () => {
     // eslint-disable-next-line no-underscore-dangle
@@ -316,7 +318,7 @@ export class RkModalImg extends RkComponent {
       headerStyle,
       footerStyle,
       source,
-      index,
+      index: initialIndex,
       style: imgStyle,
       ...imgProps
     } = this.props;
@@ -360,7 +362,7 @@ export class RkModalImg extends RkComponent {
     const closeImage = this.onCloseImage;
     const pageNumber = +this.state.index + 1;
     const totalPages = this.props.source.length;
-    const basicSource = Array.isArray(source) ? source[index] : source;
+    const basicSource = Array.isArray(source) ? source[+initialIndex] : source;
     return (
       <View>
         <TouchableWithoutFeedback
@@ -372,8 +374,8 @@ export class RkModalImg extends RkComponent {
           <Image
             source={basicSource}
             style={[img,
-            imgStyle,
-          ]}
+              imgStyle,
+            ]}
             {...imgProps}
           />
         </TouchableWithoutFeedback>
@@ -392,13 +394,13 @@ export class RkModalImg extends RkComponent {
             onLayout={Platform.OS === 'ios' ? null : this.onOrientationChange}
           >
             {Array.isArray(source) ?
-              this.onRenderImageContainer(source, index, imgProps) :
+              this.onRenderImageContainer(source, +initialIndex, imgProps) :
               this.onRenderImage(basicSource, imgProps)}
             <Animated.View style={[
               this.styles.header, {
                 opacity: this.state.opacity,
               },
-              ]}
+            ]}
             >
               {renderHeader({ closeImage, pageNumber, totalPages })}
             </Animated.View>
@@ -406,7 +408,7 @@ export class RkModalImg extends RkComponent {
               this.styles.footer, {
                 opacity: this.state.opacity,
               },
-              ]}
+            ]}
             >
               {renderFooter({ closeImage, pageNumber, totalPages })}
             </Animated.View>

--- a/src/components/image/rkModalImg.js
+++ b/src/components/image/rkModalImg.js
@@ -176,19 +176,20 @@ export class RkModalImg extends RkComponent {
       height: undefined,
       index: props.index || 0,
     };
+    this.onContainerScroll = this.onContainerScroll.bind(this);
   }
 
   componentDidUpdate() {
     if (this.needUpdateScroll && this.containerRef) {
       this.containerRef.scrollToOffset({
-        offset: this.state.index * this.state.width,
+        offset: this.props.index * this.state.width,
         animated: false,
       });
       this.needUpdateScroll = false;
     }
   }
 
-  onContainerScroll = (event) => {
+  onContainerScroll(event) {
     const currentIndex = Math.round(event.nativeEvent.contentOffset.x / this.state.width);
     if (currentIndex >= 0 &&
       currentIndex <= this.props.source.length &&
@@ -197,7 +198,7 @@ export class RkModalImg extends RkComponent {
         index: currentIndex,
       });
     }
-  };
+  }
 
   onRenderImageContainer(source, index, props) {
     return (
@@ -209,9 +210,9 @@ export class RkModalImg extends RkComponent {
         renderItem={({ item }) => this.onRenderImage(item, props)}
         horizontal
         pagingEnabled
-        keyExtractor={() => index}
+        keyExtractor={(item, srcIndex) => srcIndex}
         extraData={this.state}
-        onScroll={this.onContainerScroll}
+        onScroll={(event) => this.onContainerScroll(event)}
       />
     );
   }

--- a/src/components/image/rkModalImg.js
+++ b/src/components/image/rkModalImg.js
@@ -179,16 +179,6 @@ export class RkModalImg extends RkComponent {
     this.onContainerScroll = this.onContainerScroll.bind(this);
   }
 
-  componentDidUpdate() {
-    if (this.needUpdateScroll && this.containerRef) {
-      this.containerRef.scrollToOffset({
-        offset: this.props.index * this.state.width,
-        animated: false,
-      });
-      this.needUpdateScroll = false;
-    }
-  }
-
   onContainerScroll(event) {
     const currentIndex = Math.round(event.nativeEvent.contentOffset.x / this.state.width);
     if (currentIndex >= 0 &&
@@ -203,18 +193,24 @@ export class RkModalImg extends RkComponent {
   onRenderImageContainer(source, index, props) {
     return (
       <FlatList
-        ref={(ref) => {
-          this.containerRef = ref;
-        }}
         data={Array.from(source)}
+        getItemLayout={(item, itemIndex) => this.onRenderItemLayout(item, itemIndex)}
         renderItem={({ item }) => this.onRenderImage(item, props)}
+        initialScrollIndex={index}
         horizontal
         pagingEnabled
         keyExtractor={(item, srcIndex) => srcIndex}
-        extraData={this.state}
         onScroll={(event) => this.onContainerScroll(event)}
       />
     );
+  }
+
+  onRenderItemLayout(item, index) {
+    return {
+      index,
+      length: this.state.width,
+      offset: this.state.width * index,
+    };
   }
 
   onRenderImage(source, props) {

--- a/src/components/rkComponent.js
+++ b/src/components/rkComponent.js
@@ -120,7 +120,7 @@ export class RkComponent extends React.Component {
             styles[key] = this.getElementStyle(styles, key, typeKey, usedType[key][typeKey]);
           });
         } else {
-          let typeMappingKey = this.findTypeMappingKeyByStyleKey(this.typeMapping, key);
+          let typeMappingKey = this.findTypeMappingKeyByStyleKey(key);
           typeMappingKey = typeMappingKey || _.keys(this.typeMapping)[0];
           styles[typeMappingKey] = this.getElementStyle(styles, typeMappingKey, key, usedTypeValue);
         }
@@ -147,10 +147,10 @@ export class RkComponent extends React.Component {
     return index >= 0 ? index : element.length;
   }
 
-  findTypeMappingKeyByStyleKey(typeMapping, styleKey) {
-    // eslint-disable-next-line array-callback-return
-    const typeMappingKey = Object.keys(typeMapping).find(key => {
-      Object.prototype.hasOwnProperty.call(typeMapping[key], styleKey);
+  findTypeMappingKeyByStyleKey(styleKey) {
+    // eslint-disable-next-line arrow-body-style
+    const typeMappingKey = Object.keys(this.typeMapping).find(style => {
+      return Object.prototype.hasOwnProperty.call(this.typeMapping[style], styleKey);
     });
     return typeMappingKey || this.defaultTypeMappingStyleKey;
   }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [+] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [+] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
Fixes an issue when rkModalImg containing more than 10 items doesn't render initial clicked item.
See [issue](https://github.com/akveo/react-native-ui-kitten/issues/98).

**Notes:** this pull request should override the [previous one](https://github.com/akveo/react-native-ui-kitten/pull/114), which doesn't resolve this issue completely for Android.