### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+<a name="3.1.0"></a>
+## [3.1.0](https://github.com/akveo/react-native-ui-kitten/compare/v3.0.1...v3.1.0) (2018-09-19)
+
+
+### Bug Fixes
+
+* **rkTextInput:** non-editable rkTextInput crash on Android ([e755ce1](https://github.com/akveo/react-native-ui-kitten/commit/e755ce1))
+* **rkModalImg:** more than 10 items render ([c98d45c](https://github.com/akveo/react-native-ui-kitten/commit/c98d45c))
+* **rkCard:** nullable subview render ([0275291](https://github.com/akveo/react-native-ui-kitten/commit/0275291))
+* **rkChoice:** antialiased render on Android ([c86d57c](https://github.com/akveo/react-native-ui-kitten/commit/c86d57c))
+
+
+### Features
+
+* **build:** eslint integration and project adopt ([24d268b](https://github.com/akveo/react-native-ui-kitten/commit/24d268b))
+* **build:** add expo 27 and RN 0.56 support ([8c8b987](https://github.com/akveo/react-native-ui-kitten/commit/8c8b987))
+* **rkSwitch:** component implementation ([08dd2df](https://github.com/akveo/react-native-ui-kitten/commit/08dd2df))
+* **rkGallery:** component implementation ([2a9f652](https://github.com/akveo/react-native-ui-kitten/commit/2a9f652))
+* **rkGalleryImage:** component implementation ([794b117](https://github.com/akveo/react-native-ui-kitten/commit/794b117))
+
 <a name="3.0.1"></a>
 ## [3.0.1](https://github.com/akveo/react-native-ui-kitten/compare/v3.0.0...v3.0.1) (2018-04-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 <a name="3.1.0"></a>
 ## [3.1.0](https://github.com/akveo/react-native-ui-kitten/compare/v3.0.1...v3.1.0) (2018-09-19)
 
-
 ### Bug Fixes
 
 * **rkTextInput:** non-editable rkTextInput crash on Android ([e755ce1](https://github.com/akveo/react-native-ui-kitten/commit/e755ce1))
@@ -17,6 +16,12 @@
 * **rkSwitch:** component implementation ([08dd2df](https://github.com/akveo/react-native-ui-kitten/commit/08dd2df))
 * **rkGallery:** component implementation ([2a9f652](https://github.com/akveo/react-native-ui-kitten/commit/2a9f652))
 * **rkGalleryImage:** component implementation ([794b117](https://github.com/akveo/react-native-ui-kitten/commit/794b117))
+
+
+### Notes
+
+* **rkModalImg:** this component is deprecated since 3.1.0 version. Will be completely deleted in 3.2.0 version.
+Use [rkGallery](https://akveo.github.io/react-native-ui-kitten/#/docs/ui-components/rkgallery) or [rkGalleryImage](https://akveo.github.io/react-native-ui-kitten/#/docs/ui-components/rkgalleryimage) instead.
 
 <a name="3.0.1"></a>
 ## [3.0.1](https://github.com/akveo/react-native-ui-kitten/compare/v3.0.0...v3.0.1) (2018-04-25)

--- a/docs/structure.ts
+++ b/docs/structure.ts
@@ -206,6 +206,60 @@ export const STRUCTURE = [
       },
       {
         type: 'page',
+        name: 'RkGallery',
+        demogif: 'gallery.gif',
+        children: [
+          {
+            type: 'block',
+            block: 'rk-description',
+            klass: 'RkGallery',
+          },
+          {
+            type: 'block',
+            block: 'rk-examples',
+            klass: 'RkGallery',
+          },
+          {
+            type: 'block',
+            block: 'rk-props',
+            klass: 'RkGallery',
+          },
+          {
+            type: 'block',
+            block: 'rk-styles',
+            klass: 'RkGallery',
+          }
+        ]
+      },
+      {
+        type: 'page',
+        name: 'RkGalleryImage',
+        demogif: 'gallery.gif',
+        children: [
+          {
+            type: 'block',
+            block: 'rk-description',
+            klass: 'RkGalleryImage',
+          },
+          {
+            type: 'block',
+            block: 'rk-examples',
+            klass: 'RkGalleryImage',
+          },
+          {
+            type: 'block',
+            block: 'rk-props',
+            klass: 'RkGalleryImage',
+          },
+          {
+            type: 'block',
+            block: 'rk-styles',
+            klass: 'RkGalleryImage',
+          }
+        ]
+      },
+      {
+        type: 'page',
         name: 'RkTabView',
         demogif: 'tab.gif',
         children: [

--- a/example/screens/TabScreen.js
+++ b/example/screens/TabScreen.js
@@ -91,7 +91,7 @@ export class TabScreen extends React.Component {
         <View style={[UtilStyles.section, UtilStyles.bordered, styles.tabContainer]}>
           <RkText rkType='header' style={styles.header}>Material Theme Example</RkText>
           <View style={UtilStyles.rowContainer}>
-            <RkTabView rkType="material" tabsUnderContent={true} index='1'>
+            <RkTabView rkType="material" tabsUnderContent={true} index={1}>
               <RkTabView.Tab title="TAB 1">
                 <Image source={require('../img/river.jpeg')} />
               </RkTabView.Tab>
@@ -149,14 +149,10 @@ export class TabScreen extends React.Component {
           <RkText rkType='header' style={styles.header}>Scrollable Header</RkText>
           <View style={UtilStyles.rowContainer}>
             <RkTabView rkType='noBorders' maxVisibleTabs={3}>
-              <RkTabView.Tab
-                title={(selected) => this.renderScrollableTab(selected, 'Tab 1', 'first')}
-              />
+              <RkTabView.Tab title={(selected) => this.renderScrollableTab(selected, 'Tab 1', 'first')} />
               <RkTabView.Tab title={(selected) => this.renderScrollableTab(selected, 'Tab 2')} />
               <RkTabView.Tab title={(selected) => this.renderScrollableTab(selected, 'Tab 3')} />
-              <RkTabView.Tab
-                title={(selected) => this.renderScrollableTab(selected, 'Tab 4', 'last')}
-              />
+              <RkTabView.Tab title={(selected) => this.renderScrollableTab(selected, 'Tab 4', 'last')} />
             </RkTabView>
           </View>
         </View>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ui-kitten",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "React Native components",
   "author": "akveo",
   "homepage": "https://akveo.github.io/react-native-ui-kitten/",

--- a/src/components/avoidKeyboard/rkAvoidKeyboard.js
+++ b/src/components/avoidKeyboard/rkAvoidKeyboard.js
@@ -7,6 +7,8 @@ import {
 import { RkComponent } from '../rkComponent';
 
 /**
+ * @extends React.Component
+ *
  * `RkAvoidKeyboard` is a component for handling keyboard appearing on the screen.
  * This component is just a container for other react components.
  * In order to avoid keyboard it just changes `top` value according to keyboard height.

--- a/src/components/button/rkButton.js
+++ b/src/components/button/rkButton.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TouchableOpacity } from 'react-native';
+import {
+  TouchableOpacity,
+  ViewPropTypes,
+} from 'react-native';
 import _ from 'lodash';
 
 import { RkText } from '../text/rkText';
@@ -9,7 +12,7 @@ import { RkComponent } from '../rkComponent';
 /**
  * `RkButton` is a basic button component.
  *
- * @extends RkComponent
+ * @extends React.Component
  *
  * @example Simple usage example:
  *
@@ -133,9 +136,27 @@ import { RkComponent } from '../rkComponent';
  * instead of TouchableOpacity
  * @property {TouchableOpacity.props} props - All `TouchableOpacity` props also
  * applied to `RkButton`
+ *
  */
-
 export class RkButton extends RkComponent {
+  static propTypes = {
+    style: ViewPropTypes.style,
+    contentStyle: ViewPropTypes.style,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node,
+    ]),
+    touchable: PropTypes.func,
+  };
+  static defaultProps = {
+    style: null,
+    contentStyle: null,
+    children: [],
+    touchable: TouchableOpacity,
+  };
+  static contextTypes = {
+    theme: PropTypes.object,
+  };
   componentName = 'RkButton';
   typeMapping = {
     container: {
@@ -145,10 +166,6 @@ export class RkButton extends RkComponent {
       color: 'color',
       fontSize: 'fontSize',
     },
-  };
-
-  static contextTypes = {
-    theme: PropTypes.object,
   };
 
   renderChildren(style) {
@@ -172,10 +189,9 @@ export class RkButton extends RkComponent {
 
   render() {
     const { container, content } = super.defineStyles();
-    const { style, touchable, ...touchableProps } = this.props;
+    const { style, touchable: Touchable, ...touchableProps } = this.props;
     const hitSlop = this.extractNonStyleValue(container, 'hitSlop');
     if (hitSlop) touchableProps.hitSlop = hitSlop;
-    const Touchable = touchable || TouchableOpacity;
 
     return (
       <Touchable style={[container, style]} {...touchableProps}>

--- a/src/components/card/rkCard.js
+++ b/src/components/card/rkCard.js
@@ -1,13 +1,16 @@
 import React from 'react';
-import { View } from 'react-native';
+import {
+  View,
+  ViewPropTypes,
+} from 'react-native';
+import PropTypes from 'prop-types';
 import { RkComponent } from '../rkComponent';
 
 /**
  * `RkCard` component used to render card view in your application.
  * It's usually being used with its props applied to standard react or custom components.
  *
- * @extends RkComponent
- *
+ * @extends React.Component
  *
  * @example Usage example:
  *
@@ -106,7 +109,17 @@ import { RkComponent } from '../rkComponent';
  */
 export class RkCard extends RkComponent {
   static attrName = 'rkCard';
-
+  static propTypes = {
+    style: ViewPropTypes.style,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node,
+    ]),
+  };
+  static defaultProps = {
+    style: null,
+    children: [],
+  };
   componentName = 'RkCard';
   typeMapping = {
     container: {},

--- a/src/components/choice/rkChoice.js
+++ b/src/components/choice/rkChoice.js
@@ -2,14 +2,16 @@ import React from 'react';
 import {
   TouchableOpacity,
   Image,
+  ViewPropTypes,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { RkComponent } from '../rkComponent';
 
 /**
  * `RkChoice` component is an analog of html checkbox and radio buttons.
  *
- * @extends RkComponent
+ * @extends React.Component
  *
  * @example Simple usage example:
  *
@@ -175,8 +177,25 @@ import { RkComponent } from '../rkComponent';
  * @property {style} style - Style for `container` component
  * @property {style} contentStyle - Style for `inner` component
  */
-
 export class RkChoice extends RkComponent {
+  static propTypes = {
+    rkType: PropTypes.string,
+    style: ViewPropTypes.style,
+    contentStyle: ViewPropTypes.style,
+    selected: PropTypes.bool,
+    disabled: PropTypes.bool,
+    onChange: PropTypes.func,
+    renderContentFunction: PropTypes.func,
+  };
+  static defaultProps = {
+    rkType: '',
+    style: null,
+    contentStyle: null,
+    selected: false,
+    disabled: false,
+    onChange: (() => null),
+    renderContentFunction: undefined,
+  };
   componentName = 'RkChoice';
   typeMapping = {
     container: {},
@@ -188,8 +207,8 @@ export class RkChoice extends RkComponent {
   constructor(props) {
     super(props);
     this.state = {
-      selected: props.selected || false,
-      disabled: props.disabled || false,
+      selected: props.selected,
+      disabled: props.disabled,
     };
   }
 
@@ -201,9 +220,7 @@ export class RkChoice extends RkComponent {
 
   onPress(e) {
     this.setState({ selected: !this.state.selected });
-    if (this.props.onChange) {
-      this.props.onChange(this.state.selected, e);
-    }
+    this.props.onChange(this.state.selected, e);
   }
 
   renderDefaultContentView(style) {

--- a/src/components/choiceGroup/rkChoiceGroup.js
+++ b/src/components/choiceGroup/rkChoiceGroup.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import { View } from 'react-native';
+import {
+  View,
+  ViewPropTypes,
+} from 'react-native';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { RkChoice } from '../choice/rkChoice';
 import { RkComponent } from '../rkComponent';
@@ -8,7 +12,8 @@ import { RkComponent } from '../rkComponent';
  * `RkChoiceGroup` component is container for elements
  * that can be used as checkboxes or radio buttons.
  * Used usually in combination with `RkChoice` component.
- * @extends RkComponent
+ *
+ * @extends React.Component
  *
  * @example Simple usage with labels
  *
@@ -108,9 +113,32 @@ import { RkComponent } from '../rkComponent';
  * @property {function} onChange - Called when state of RkChoice is changed.
  */
 export class RkChoiceGroup extends RkComponent {
+  static propTypes = {
+    selectedIndex: PropTypes.number,
+    radio: PropTypes.bool,
+    onChange: PropTypes.func,
+    disabled: PropTypes.bool,
+    style: ViewPropTypes.style,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node,
+    ]),
+  };
+  static defaultProps = {
+    selectedIndex: undefined,
+    radio: false,
+    onChange: (() => null),
+    disabled: false,
+    style: null,
+    children: [],
+  };
   componentName = 'RkChoiceGroup';
   typeMapping = {
     container: {},
+  };
+
+  state = {
+    selectionWasUpdated: false,
   };
 
   constructor(props) {
@@ -119,9 +147,6 @@ export class RkChoiceGroup extends RkComponent {
     if (props.selectedIndex !== undefined) {
       this.choice[props.selectedIndex] = true;
     }
-    this.state = {
-      selectionWasUpdated: false,
-    };
   }
 
   componentWillMount() {
@@ -142,9 +167,7 @@ export class RkChoiceGroup extends RkComponent {
       this.clearChoice();
     }
     this.choice[index] = this.props.radio ? true : !this.choice[index];
-    if (this.props.onChange) {
-      this.props.onChange(index);
-    }
+    this.props.onChange(index);
     this.setState({ selectionWasUpdated: true });
   }
 

--- a/src/components/gallery/rkGallery.js
+++ b/src/components/gallery/rkGallery.js
@@ -12,17 +12,21 @@ import { RkGalleryHeaderFooter } from './RkGalleryHeaderFooter';
 import { RkButton } from '../button/rkButton';
 
 /**
- * `RkGallery` is a component which displays a grid of images or a list of modal images
- * depending on state:
- * - Tap a single item in a grid to view it in modal.
- * - Double tap a modal item to pinch-to-zoom it.
+ * `RkGallery` is a component which displays a grid of images or a horizontal list of modal images
+ * depending on user behavior:
+ * Single tap on grid item to view image in modal.
+ * Double tap a modal item to pinch-to-zoom image.
+ * Swipe modal item right or left to switch next or previous image.
  *
  * @extends RkComponent
  *
- * @example Simple usage:
+ * @example Simple usage example:
  *
  * ```
- * <RkGallery items={[item1, item2, ...]} />
+ * <RkGallery items={[
+ *   require('path/to/my-awesome-pic-0.jpg'),
+ *   require('path/to/my-awesome-pic-1.jpg'),
+ * ]} />
  * ```
  *
  * @example Custom header/footer
@@ -34,62 +38,120 @@ import { RkButton } from '../button/rkButton';
  * <RkGallery
  *   items={[item1, item2, ...]}
  *   renderGalleryHeader={this.renderGalleryHeader}
- *   renderGalleryFooter={this.renderGalleryFooter}/>
- * ```
+ *   renderGalleryFooter={this.renderGalleryFooter}
+ * />
  *
- * Render custom header:
- * @param onRequestClose - default modal closing behavior which should be passed to any
- * component able to perform a 'close' action.
+ * // @param onRequestClose - default modal closing behavior which should
+ * // be passed to any component able to perform a 'close' action.
  *
- * ```
  * renderGalleryHeader = (onRequestClose) => (
  *   <View>
  *    <RkButton onPress={onRequestClose}>Back</RkButton>
  *   </View>
  * );
- * ```
  *
- * Render custom footer:
- *
- * ```
  * renderGalleryFooter = () => (
  *   <View>
- *     <RkButton onPress={(x) => Alert.alert('I Like it!')}>Custom Footer</RkButton>
+ *     <RkButton onPress={this.onGalleryFooterButtonPressed}>Custom Footer</RkButton>
  *   </View>
  * );
  *
- * @example Styling
+ * onGalleryFooterButtonPressed = () => {
+ *   // whatever
+ * };
+ * ```
  *
- * `RkGallery` supports both styling via default `style` prop and using rkType.
- * Using style prop you only customize a state where it is a grid of items, not modal.
- * To customize a grid item use an `itemStyle` prop.
- * Also there is a `spanCount` prop which can be used to define a number of columns in a grid.
- *
- * Rounded items with custom spacing:
+ * @example Handling component events:
  *
  * ```
  * <RkGallery
  *  items={[item1, item2, ...]}
- *  itemStyle={{ borderRadius: 8, margin: 1 }}/>
+ *  onGridItemClick={this.onGridItemClick}
+ *  onGalleryItemClick={this.onGalleryItemClick}
+ *  onGalleryItemChange={this.onGalleryItemChange}
+ *  onGalleryItemScaleChange={this.onGalleryItemScaleChange}
+ * />
+ *
+ * // Grid item click:
+ * // Default behavior is to open a clicked grid item in modal, so you can't change this.
+ * // Just do some work you need to be done on item click.
+ * //
+ * // @param item - grid image item
+ * // @param index - grid image item index
+ *
+ * onGridItemClick = (item, index) => {
+ *  // whatever
+ * };
+ *
+ * // Modal item click:
+ * // Default behavior is to show/hide header and footer, so you can't change this.
+ * // Just do some work you need to be done on item click.
+ * // @param item - modal image item
+ * // @param index - modal image item index
+ *
+ * onGalleryItemClick = (item, index) => {
+ *  // whatever
+ * };
+ *
+ * // Modal item change:
+ * // Called when:
+ * // - default swipe right/left gesture is performed,
+ * // - grid item becomes modal,
+ * // - modal item becomes back to grid,
+ * //
+ * // @param change - object containing previous and current item indexes:
+ * //
+ * // Grid item with index 0 becomes modal:
+ * // {
+ * //  previous: undefined,
+ * //  current: 0,
+ * // }
+ * //
+ * // Swipe next:
+ * // {
+ * //  previous: 0,
+ * //  current: 1,
+ * // }
+ * //
+ * // Close modal on item 4:
+ * // {
+ * //  previous: 4,
+ * //  current: undefined,
+ * // }
+ *
+ * onGalleryItemChange = (change) => {
+ *  // whatever
+ * };
+ *
+ * // Modal item scale change:
+ * // Called when:
+ * // - pinch gesture is performed,
+ * // - double click is performed
+ * //
+ * // @param item - modal image item,
+ * // @param index - modal image item index,
+ * // @param change - object containing previous and current image scale args:
+ * //
+ * // Double click:
+ * //
+ * // {
+ * //  previous: 1.0,
+ * //  current: 2.0
+ * // }
+ *
+ * onGalleryItemScaleChange = (item, index, change) => {
+ *  // whatever
+ * };
  * ```
- *
- * Four columns:
- *
- * ```
- * <RkGallery
- *  items={[item1, item2, ...]}
- *  spanCount={4} />
- * ```
- *
- * Using rkType:
- *
+
  *
  * @example Define new rkTypes
  *
- * `RkGallery` doesn't have predefined rkTypes.
+ * `RkGallery` doesn't have predefined `rkType`s.
  *  However, it's easy and very common to create new types.
  *  Main point for all customization is `RkTheme` object.
  *  New rkTypes are defined using `setType` method of `RkTheme`.
+ *  Available for stylization components are: `grid`, `gridItem`, `previewHeader`, `previewFooter`.
  *
  * ```
  * RkTheme.setType('RkGallery', 'projectDefault', {
@@ -100,130 +162,25 @@ import { RkButton } from '../button/rkButton';
  * });
  * ```
  *
- * ```
- *  <RkModalImg
- *    rkType='projectDefault'
- *    items={[item1, item2, ...]}/>
- * ```
- *
  * @styles Available components:
  * - `grid`: `FlatList` - container in a grid (not modal) mode,
  * - `gridItem`: `TouchableWithoutFeedback ` - item inside container in a grid (not modal) mode,
  * - `previewHeader`: `View` - Header of container in a modal mode,
  * - `previewFooter`: `View` - Footer of container in a modal mode,
  *
- * @example Handling component events:
- * @see RkGalleryImage
- *
- * The following events can be handled outside the component:
- *
- * - Grid item click: use an onGridItemClick prop,
- * - Modal item click: use an onGalleryItemClick prop,
- * - Modal item change: use an onGalleryItemChange prop,
- * - Modal item scale change (pinch-zoom effect): use an onGalleryItemScaleChange prop.
- *
- * ```
- * <RkGallery
- *  items={[item1, item2, ...]}
- *  onGridItemClick={this.onGridItemClick}
- *  onGalleryItemClick={this.onGalleryItemClick}
- *  onGalleryItemChange={this.onGalleryItemChange}
- *  onGalleryItemScaleChange={this.onGalleryItemScaleChange}
- * />
- * ```
- *
- * Grid item click:
- * Default behavior is to open a clicked grid item in modal, so you can't change this.
- * Just do some work you need to be done on item click.
- * @param item - grid image item
- * @param index - grid image item index
- *
- * ```
- * onGridItemClick = (item, index) => {
- *  // whatever
- * };
- * ```
- *
- * Modal item click:
- * Default behavior is to show/hide header and footer, so you can't change this.
- * Just do some work you need to be done on item click.
- * @param item - modal image item
- * @param index - modal image item index
- *
- * ```
- * onGalleryItemClick = (item, index) => {
- *  // whatever
- * };
- * ```
- *
- * Modal item change:
- * Called when:
- * - default swipe right/left gesture is performed,
- * - grid item becomes modal,
- * - modal item becomes back to grid,
- *
- * @param change - object containing previous and current item indexes:
- *
- * Grid item with index 0 becomes modal:
- * {
- *  previous: undefined,
- *  current: 0,
- * }
- *
- * Swipe next:
- * {
- *  previous: 0,
- *  current: 1,
- * }
- *
- * Close modal on item 4:
- * {
- *  previous: 4,
- *  current: undefined,
- * }
- *
- * ```
- * onGalleryItemChange = (change) => {
- *  // whatever
- * };
- * ```
- *
- * Modal item scale change:
- * Called when:
- * - pinch gesture is performed,
- * - double click is performed
- *
- * @param item - modal image item,
- * @param index - modal image item index,
- * @param change - object containing previous and current image scale args:
- *
- * Double click:
- *
- * {
- *  previous: 1.0,
- *  current: 2.0
- * }
- *
- * ```
- * onGalleryItemScaleChange = (item, index, change) => {
- *  // whatever
- * };
- * ```
- *
- * @property {string} rkType - Types for component stylization,
- * @property {style} style - Style for container in grid mode,
- * @property {style} itemStyle - Style for image in grid mode,
- * @property {function} renderGalleryHeader - Function for rendering custom header,
- * @property {function} renderGalleryFooter - Function for rendering custom footer,
- * @property {number} spanCount - number of container columns in a grid mode,
+ * @property {string} rkType - Types for component stylization
+ * @property {style} style - Style for container in grid mode
+ * @property {style} itemStyle - Style for image in grid mode
+ * @property {function} renderGalleryHeader - Function for rendering custom header
+ * @property {function} renderGalleryFooter - Function for rendering custom footer
+ * @property {number} spanCount - number of container columns in a grid mode
  * @property {number} galleryItemMaxScale - maximum scale of a modal item applied via pinch gesture
- * or double click,
- * @property {function} onGridItemClick - Grid item click callback,
- * @property {function} onGalleryItemClick - Gallery (modal) item click callback,
- * @property {function} onGalleryItemChange - Gallery (modal) item change callback,
- * @property {function} onGalleryItemScaleChange - Gallery (modal) item scale change callback.
- */
-
+ * or double click
+ * @property {function} onGridItemClick - Grid item click callback
+ * @property {function} onGalleryItemClick - Gallery (modal) item click callback
+ * @property {function} onGalleryItemChange - Gallery (modal) item change callback
+ * @property {function} onGalleryItemScaleChange - Gallery (modal) item scale change callback
+ * */
 export class RkGallery extends RkComponent {
   static propTypes = {
     items: RkGalleryGrid.propTypes.items,

--- a/src/components/gallery/rkGallery.js
+++ b/src/components/gallery/rkGallery.js
@@ -4,6 +4,7 @@ import {
   View,
   Animated,
   StyleSheet,
+  ViewPropTypes,
 } from 'react-native';
 import { RkComponent } from '../rkComponent';
 import { RkGalleryGrid } from './rkGalleryGrid';
@@ -18,7 +19,7 @@ import { RkButton } from '../button/rkButton';
  * Double tap a modal item to pinch-to-zoom image.
  * Swipe modal item right or left to switch next or previous image.
  *
- * @extends RkComponent
+ * @extends React.Component
  *
  * @example Simple usage example:
  *
@@ -175,15 +176,16 @@ import { RkButton } from '../button/rkButton';
  * @property {function} renderGalleryFooter - Function for rendering custom footer
  * @property {number} spanCount - number of container columns in a grid mode
  * @property {number} galleryItemMaxScale - maximum scale of a modal item applied via pinch gesture
- * or double click
- * @property {function} onGridItemClick - Grid item click callback
- * @property {function} onGalleryItemClick - Gallery (modal) item click callback
- * @property {function} onGalleryItemChange - Gallery (modal) item change callback
- * @property {function} onGalleryItemScaleChange - Gallery (modal) item scale change callback
- * */
+ * or double click,
+ * @property {function} onGridItemClick - Grid item click callback,
+ * @property {function} onGalleryItemClick - Gallery (modal) item click callback,
+ * @property {function} onGalleryItemChange - Gallery (modal) item change callback,
+ * @property {function} onGalleryItemScaleChange - Gallery (modal) item scale change callback.
+ */
 export class RkGallery extends RkComponent {
   static propTypes = {
-    items: RkGalleryGrid.propTypes.items,
+    rkType: RkComponent.propTypes.rkType,
+    items: RkGalleryGrid.propTypes.items.isRequired,
     itemStyle: RkGalleryGrid.propTypes.itemStyle,
     renderGalleryHeader: RkGalleryHeaderFooter.propTypes.onRenderComponent,
     renderGalleryFooter: RkGalleryHeaderFooter.propTypes.onRenderComponent,
@@ -193,15 +195,20 @@ export class RkGallery extends RkComponent {
     onGalleryItemClick: RkGalleryViewer.propTypes.onItemClick,
     onGalleryItemChange: RkGalleryViewer.propTypes.onItemChange,
     onGalleryItemScaleChange: RkGalleryViewer.propTypes.onItemScaleChange,
+    style: ViewPropTypes.style,
   };
   static defaultProps = {
+    rkType: RkComponent.defaultProps.rkType,
+    itemStyle: RkGalleryGrid.defaultProps.itemStyle,
     renderGalleryHeader: null,
     renderGalleryFooter: null,
     spanCount: RkGalleryGrid.defaultProps.spanCount,
+    galleryItemMaxScale: RkGalleryViewer.defaultProps.itemMaxScale,
     onGridItemClick: RkGalleryGrid.defaultProps.onItemClick,
     onGalleryItemClick: RkGalleryViewer.defaultProps.onItemClick,
     onGalleryItemChange: RkGalleryViewer.defaultProps.onItemChange,
     onGalleryItemScaleChange: RkGalleryViewer.defaultProps.onItemScaleChange,
+    style: null,
   };
   componentName = 'RkGallery';
   typeMapping = {
@@ -217,10 +224,6 @@ export class RkGallery extends RkComponent {
   };
 
   isPreview = () => this.state.previewImageIndex !== undefined;
-
-  defineStyles(rkType) {
-    return super.defineStyles(rkType);
-  }
 
   // eslint-disable-next-line arrow-body-style
   getOverlayAnimation = (endValue) => {
@@ -316,7 +319,7 @@ export class RkGallery extends RkComponent {
   };
 
   renderGrid = () => {
-    const { grid, gridItem } = this.defineStyles(this.props.rkType);
+    const { grid, gridItem } = super.defineStyles(this.props.rkType);
     return (
       <RkGalleryGrid
         style={[grid, this.props.style]}

--- a/src/components/gallery/rkGalleryGrid.js
+++ b/src/components/gallery/rkGalleryGrid.js
@@ -10,13 +10,14 @@ import PropTypes from 'prop-types';
 
 export class RkGalleryGrid extends React.Component {
   static propTypes = {
-    items: PropTypes.node.isRequired,
+    items: PropTypes.arrayOf(PropTypes.node),
     spanCount: PropTypes.number,
     onItemClick: PropTypes.func,
     style: ViewPropTypes.style,
     itemStyle: ViewPropTypes.style,
   };
   static defaultProps = {
+    items: [],
     spanCount: 3,
     onItemClick: (() => null),
     style: null,

--- a/src/components/gallery/rkGalleryImage.js
+++ b/src/components/gallery/rkGalleryImage.js
@@ -8,7 +8,7 @@ import { PinchZoomResponder } from './pinchZoomResponder';
 /**
  * `RkGalleryImage` is a component which displays an image with pinch-zoom and double click support.
  *
- * @extends RkComponent
+ * @extends React.Component
  *
  * @example Simple usage example:
  *
@@ -83,7 +83,6 @@ import { PinchZoomResponder } from './pinchZoomResponder';
  * @property {function} onScaleChange - item scale change callback,
  * @property {function} onOffsetChange - item offset change callback.
  */
-
 export class RkGalleryImage extends RkComponent {
   static propTypes = {
     source: PropTypes.node.isRequired,
@@ -95,6 +94,8 @@ export class RkGalleryImage extends RkComponent {
   static defaultProps = {
     maxScale: PinchZoomResponder.defaultProps.maxScale,
     onClick: (() => null),
+    onScaleChange: PinchZoomResponder.defaultProps.onScaleChange,
+    onOffsetChange: PinchZoomResponder.defaultProps.onOffsetChange,
   };
   componentName = 'RkGalleryImage';
 
@@ -129,17 +130,15 @@ export class RkGalleryImage extends RkComponent {
   };
 
   render() {
-    const { scalable, ...restProps } = this.props;
     return (
       <PinchZoomResponder
         ref={this.setPinchResponderRef}
-        scalable={scalable}
         onScaleChange={this.onImageScaleChange}
         onOffsetChange={this.onImageOffsetChange}>
         <DoubleTouchableWithoutFeedback
           onSinglePress={this.onImageSinglePress}
           onDoublePress={this.onImageDoublePress}>
-          <Image{...restProps} />
+          <Image{...this.props} />
         </DoubleTouchableWithoutFeedback>
       </PinchZoomResponder>
     );

--- a/src/components/gallery/rkGalleryImage.js
+++ b/src/components/gallery/rkGalleryImage.js
@@ -10,19 +10,13 @@ import { PinchZoomResponder } from './pinchZoomResponder';
  *
  * @extends RkComponent
  *
- * @example Simple usage:
+ * @example Simple usage example:
  *
  * ```
- * <RkGalleryImage source={require('path/to/awesome-pic.jpg')}/>
+ * <RkGalleryImage source={require('path/to/my-awesome-pic.jpg')}/>
  * ```
  *
- * @example Handling component events:
- *
- * The following events can be handled outside the component:
- *
- * - Item click: use an onClick prop,
- * - Item scale change (pinch-zoom effect): use an onScaleChange prop,
- * - Item offset change (pinch-zoom effect): use an onOffsetChange prop.
+ * @example Handling component events
  *
  * ```
  * <RkGalleryImage
@@ -31,57 +25,52 @@ import { PinchZoomResponder } from './pinchZoomResponder';
  *  onScaleChange={this.onImageScaleChange}
  *  onOffsetChange={this.onImageOffsetChange}
  * />
- * ```
  *
- * Item click:
- * Do some work you need to be done on item click.
- * @param event - default react-native click event object.
+ * // Click:
+ * // Do some work you need to be done on item click.
+ * //
+ * // @param event - default react-native click event object.
  *
- * ```
- * onImageClick = (event) => {
+ * onImageClick = (item, index) => {
  *  // whatever
  * };
- * ```
  *
- * Item scale change:
- * Called when:
- * - pinch gesture is performed,
- * - double click is performed
+ * // Scale change:
+ * // Called when:
+ * // - pinch gesture is performed,
+ * // - double click is performed
+ * //
+ * // @param change - object containing previous and current image scale args:
+ * //
+ * // Double click:
+ * //
+ * // {
+ * //  previous: 1.0,
+ * //  current: 2.0
+ * // }
  *
- * @param change - object containing previous and current image scale args:
- *
- * Double click:
- *
- * {
- *  previous: 1.0,
- *  current: 2.0
- * }
- *
- * ```
  * onImageScaleChange = (change) => {
  *  // whatever
  * };
- * ```
  *
- * Item offset change:
- * Called when panning scaled image.
+ * // Item offset change:
+ * // Called when panning scaled image.
+ * //
+ * // @param change - object containing previous and current image offset args:
+ * //
+ * // Double click:
+ * //
+ * // {
+ * //  previous: {
+ * //    x: 0.0,
+ * //    y: 0.0,
+ * //  },
+ * //  current: {
+ * //    x: 32.0,
+ * //    y: 64.0,
+ * //  }
+ * // }
  *
- * @param change - object containing previous and current image offset args:
- *
- * Double click:
- *
- * {
- *  previous: {
- *    x: 0.0,
- *    y: 0.0,
- *  },
- *  current: {
- *    x: 32.0,
- *    y: 64.0,
- *  }
- * }
- *
- * ```
  * onImageOffsetChange = (change) => {
  *  // whatever
  * };

--- a/src/components/image/rkModalImg.js
+++ b/src/components/image/rkModalImg.js
@@ -18,12 +18,21 @@ import { RkComponent } from '../rkComponent';
 import { RkTheme } from '../../styles/themeManager';
 
 /**
+ * `RkModalImg` is extension of basic `Image` that also opens it in full screen on tap.
+ *
  * @deprecated since version 3.1.0. Will be deleted in version 3.2.0.
  * Use `RkGallery` or `RkGalleryImage` instead.
  *
- * `RkModalImg` is extension of basic `Image` that also opens it in full screen on tap.
- *
  * @extends React.Component
+ *
+ * @example Important notes
+ *
+ * Deprecated since version 3.1.0. Will be deleted in version 3.2.0.
+ * Use `RkGallery` or `RkGalleryImage` instead.
+ *
+ * ```
+ * <RkGalleryImage source={require('path/to/my-awesome-pic.jpg')}/>
+ * ```
  *
  * @example Simple usage:
  *

--- a/src/components/image/rkModalImg.js
+++ b/src/components/image/rkModalImg.js
@@ -16,6 +16,9 @@ import { RkComponent } from '../rkComponent';
 import { RkTheme } from '../../styles/themeManager';
 
 /**
+ * @deprecated since version 3.1.0. Will be deleted in version 3.2.0.
+ * Use `RkGallery` or `RkGalleryImage` instead.
+ *
  * `RkModalImg` is extension of basic `Image` that also opens it in full screen on tap.
  *
  * @extends RkComponent

--- a/src/components/picker/rkPicker.js
+++ b/src/components/picker/rkPicker.js
@@ -1,5 +1,10 @@
 import React from 'react';
-import { Modal, View } from 'react-native';
+import {
+  View,
+  Modal,
+  ViewPropTypes,
+} from 'react-native';
+import PropTypes from 'prop-types';
 import { RkButton } from '../button/rkButton';
 import { RkText } from '../text/rkText';
 import { RkComponent } from '../rkComponent';
@@ -8,7 +13,7 @@ import { RkOptionsList } from './rkOptionsList';
 /**
  * `RkPicker` is a modal window with lists of options that can be selected
  *
- * @extends RkComponent
+ * @extends React.Component
  *
  * @example Usage example:
  *
@@ -149,9 +154,50 @@ import { RkOptionsList } from './rkOptionsList';
  * Default value: 3
  * @property {string} optionRkType - Types for RkText component with option
  * @property {string} selectedOptionRkType - Types for RkText component with selected option
-
  */
 export class RkPicker extends RkComponent {
+  static propTypes = {
+    rkType: RkComponent.propTypes.rkType,
+    // eslint-disable-next-line react/forbid-prop-types
+    data: PropTypes.array.isRequired,
+    optionRkType: RkComponent.propTypes.rkType,
+    selectedOptionRkType: RkComponent.propTypes.rkType,
+    // eslint-disable-next-line react/forbid-prop-types
+    selectedOptions: PropTypes.array,
+    optionHeight: PropTypes.number,
+    optionNumberOnPicker: PropTypes.number,
+    confirmButtonText: PropTypes.string,
+    cancelButtonText: PropTypes.string,
+    confirmTextRkType: PropTypes.string,
+    cancelTextRkType: PropTypes.string,
+    confirmButtonRkType: PropTypes.string,
+    cancelButtonRkType: PropTypes.string,
+    titleTextRkType: PropTypes.string,
+    onConfirm: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    style: ViewPropTypes.style,
+    title: PropTypes.string,
+    visible: PropTypes.bool,
+  };
+  static defaultProps = {
+    rkType: RkComponent.defaultProps.rkType,
+    optionRkType: RkComponent.defaultProps.rkType,
+    selectedOptionRkType: RkComponent.defaultProps.rkType,
+    selectedOptions: [],
+    optionHeight: 50,
+    optionNumberOnPicker: 3,
+    confirmButtonText: 'OK',
+    cancelButtonText: 'CANCEL',
+    confirmTextRkType: 'header',
+    cancelTextRkType: '',
+    confirmButtonRkType: 'transparent rectangle',
+    cancelButtonRkType: 'transparent rectangle',
+    titleTextRkType: 'header',
+    style: null,
+    title: '',
+    visible: true,
+  };
+
   componentName = 'RkPicker';
   typeMapping = {
     modalContainerBlock: {},
@@ -180,49 +226,60 @@ export class RkPicker extends RkComponent {
     },
   };
 
+  state = {
+    scrollToSelected: false,
+    selectedOptions: [],
+  };
+
   constructor(props) {
     super(props);
-    this.optionHeight = this.props.optionHeight || 50;
-    this.optionNumberOnPicker = this.props.optionNumberOnPicker || 3;
-    this.pickerHeight = this.optionNumberOnPicker * this.optionHeight;
-    this.confirmButtonText = this.props.confirmButtonText || 'OK';
-    this.cancelButtonText = this.props.cancelButtonText || 'CANCEL';
-    this.confirmTextRkType = this.props.confirmTextRkType || 'header';
-    this.cancelTextRkType = this.props.cancelTextRkType || '';
-    this.confirmButtonRkType = this.props.confirmButtonRkType || 'transparent rectangle';
-    this.cancelButtonRkType = this.props.cancelButtonRkType || 'transparent rectangle';
-    this.titleTextRkType = this.props.titleTextRkType || 'header';
-    this.state = {
-      scrollToSelected: false,
-      selectedOptions: this.props.selectedOptions.slice(),
-    };
-  }
-
-  onRenderOptionContainer(items, index, optionBlock, highlightBlock, optionListContainer) {
-    return (
-      <RkOptionsList
-        rkType={this.props.rkType}
-        key={index}
-        id={index}
-        data={items}
-        selectedOption={this.state.selectedOptions[index]}
-        scrollToSelected={this.state.scrollToSelected}
-        onSelect={(option, optionIndex) => this.onOptionSelect(option, optionIndex)}
-        optionHeight={this.optionHeight}
-        optionNumberOnPicker={this.optionNumberOnPicker}
-        optionRkType={this.props.optionRkType}
-        selectedOptionRkType={this.props.selectedOptionRkType}
-        optionBlockStyle={optionBlock}
-        highlightBlockStyle={highlightBlock}
-        optionListContainerStyle={optionListContainer}
-      />
-    );
+    this.state.selectedOptions = this.props.selectedOptions.slice();
   }
 
   onOptionSelect(item, index) {
     this.state.scrollToSelected = this.props.visible;
     this.state.selectedOptions[index] = item;
   }
+
+  onConfirmButtonPress = () => {
+    this.props.onConfirm(this.state.selectedOptions);
+  };
+
+  onCancelButtonPress = () => {
+    this.props.onCancel();
+  };
+
+  onMondalRequestClose = () => {
+    this.props.onCancel();
+  };
+
+  renderOptions = (optionBlock, highlightBlock, container) => this.props.data.map((array, index) =>
+    this.renderOptionContainer(
+      array,
+      index,
+      optionBlock,
+      highlightBlock,
+      container,
+    ));
+
+  renderOptionContainer = (items, index, optionBlock, highlightBlock, optionListContainer) => (
+    <RkOptionsList
+      rkType={this.props.rkType}
+      key={index}
+      id={index}
+      data={items}
+      selectedOption={this.state.selectedOptions[index]}
+      scrollToSelected={this.state.scrollToSelected}
+      onSelect={(option, optionIndex) => this.onOptionSelect(option, optionIndex)}
+      optionHeight={this.props.optionHeight}
+      optionNumberOnPicker={this.props.optionNumberOnPicker}
+      optionRkType={this.props.optionRkType}
+      selectedOptionRkType={this.props.selectedOptionRkType}
+      optionBlockStyle={optionBlock}
+      highlightBlockStyle={highlightBlock}
+      optionListContainerStyle={optionListContainer}
+    />
+  );
 
   render() {
     const {
@@ -237,41 +294,39 @@ export class RkPicker extends RkComponent {
       highlightBlock,
       optionListContainer,
     } = super.defineStyles(this.props.rkType);
+    const { optionNumberOnPicker: optionCount, optionHeight } = this.props;
 
     return (
       <Modal
         visible={this.props.visible}
         animationType="fade"
         transparent={true}
-        onRequestClose={() => this.props.onCancel()}>
+        onRequestClose={this.onMondalRequestClose}>
         <View style={[modalContainerBlock]}>
           <View style={[modalContentBlock, this.props.style]}>
             <RkText
-              rkType={this.titleTextRkType}
+              rkType={this.props.titleTextRkType}
               style={titleBlock}>{this.props.title}
             </RkText>
-            <View style={[listsContainerBlock, { height: this.pickerHeight }]}>
-              {this.props.data.map((array, index) =>
-                this.onRenderOptionContainer(
-                  array,
-                  index,
-                  optionBlock,
-                  highlightBlock,
-                  optionListContainer,
-                ))}
+            <View style={[listsContainerBlock, { height: optionCount * optionHeight }]}>
+              {this.renderOptions(optionBlock, highlightBlock, optionListContainer)}
             </View>
             <View style={[buttonsBlockBlock]}>
               <RkButton
-                rkType={this.cancelButtonRkType}
+                rkType={this.props.cancelButtonRkType}
                 style={cancelButtonBlock}
-                onPress={() => this.props.onCancel()}>
-                <RkText rkType={this.cancelTextRkType}>{this.cancelButtonText}</RkText>
+                onPress={this.onCancelButtonPress}>
+                <RkText rkType={this.props.cancelTextRkType}>
+                  {this.props.cancelButtonText}
+                </RkText>
               </RkButton>
               <RkButton
-                rkType={this.confirmButtonRkType}
+                rkType={this.props.confirmButtonRkType}
                 style={confirmButtonBlock}
-                onPress={() => this.props.onConfirm(this.state.selectedOptions)}>
-                <RkText rkType={this.confirmTextRkType}>{this.confirmButtonText}</RkText>
+                onPress={this.onConfirmButtonPress}>
+                <RkText rkType={this.props.confirmTextRkType}>
+                  {this.props.confirmButtonText}
+                </RkText>
               </RkButton>
             </View>
           </View>

--- a/src/components/switch/rkSwitch.android.js
+++ b/src/components/switch/rkSwitch.android.js
@@ -14,6 +14,84 @@ const switchWidth = 52;
 const switchOffsetValue = 20;
 const thumbSize = switchHeight - (switchBorderWidth * 2);
 
+/**
+ * `RkSwitch` is a component which looks like a standard iOS switch on both platforms.
+ *
+ * @extends RkComponent
+ *
+ * @example Simple usage example:
+ *
+ * ```
+ * state = {
+ *   value: false, // switch is disabled by default
+ * };
+ *
+ * <RkSwitch
+ *   value={this.state.value}
+ *   onValueChange={this.onSwitchValueChange}
+ * />
+ *
+ * onSwitchValueChange = () => {
+ *   this.setState({value: !this.state.value}
+ * };
+
+ * ```
+ *
+ * @example Custom colors
+ *
+ * As in a standard react-native's Switch,
+ * colors of the control can be configured via appropriate props:
+ *
+ * ```
+ * <RkSwitch
+ *   tintColor='blue'
+ *   onTintColor='yellow'
+ *   thumbTintColor='purple'
+ *   value={this.state.value}
+ *   onValueChange={this.onSwitchValueChange)}
+ * />
+ * ```
+ *
+ * @example Using rkType prop
+ *
+ * `RkSwitch` has `rkType` prop. This prop works similar to CSS-class in web.
+ * It is possible to set more than one type.
+ * There is a possibility to control tint colors via `rkType`s.
+ * Available `rkType`s: `primary`, `success`, `info`, `warning`, `danger`.
+ *
+ * ```
+ * <RkSwitch
+ *   rkType='danger'
+ *   value={this.state.value}
+ *   onValueChange={this.onSwitchValueChange}
+ * />
+ * ```
+ *
+ * @example Define new rkTypes
+ *
+ * New rkTypes are defined using `setType` method of `RkTheme`.
+ *
+ * ```
+ * RkTheme.setType('RkSwitch', 'projectDefault', {
+ *   tintColor: 'blue',
+ *   onTintColor: 'yellow',
+ *   thumbTintColor: 'purple',
+ *   margin: 10,
+ * });
+ * ```
+ *
+ * @styles Available style properties:
+ * - `tintColor` : will be converted into `tintColor` prop of `Switch`
+ * - `onTintColor` : will be converted into `onTintColor` prop of `Switch`
+ * - `thumbTintColor` : will be converted into `thumbTintColor` prop of `Switch`
+ * - ...: Any other style properties will be applied to `View` container.
+ *
+ * @property {string} rkType - Types for component stylization
+ * By default `RkSwitch` supports following types: `primary`, `warning`, `danger`, `success`, `info`
+ * @property {style} style - Style for `View` container
+ * @property {Switch.props} props - All `Switch` props also applied to `RkSwitch`
+ */
+
 export class RkSwitch extends RkComponent {
   componentName = 'RkSwitch';
   typeMapping = {

--- a/src/components/switch/rkSwitch.ios.js
+++ b/src/components/switch/rkSwitch.ios.js
@@ -14,42 +14,62 @@ import { RkComponent } from '../rkComponent';
  * @example Simple usage example:
  *
  * ```
- * <RkSwitch value={this.state.value}
- *           onValueChange={() => this.setState({value: !this.state.value})}/>
+ * state = {
+ *   value: false, // switch is disabled by default
+ * };
+ *
+ * <RkSwitch
+ *   value={this.state.value}
+ *   onValueChange={this.onSwitchValueChange}
+ * />
+ *
+ * onSwitchValueChange = () => {
+ *   this.setState({value: !this.state.value}
+ * };
+
  * ```
  *
- * @example Color settings
+ * @example Custom colors
  *
  * As in a standard react-native's Switch,
  * colors of the control can be configured via appropriate props:
  *
  * ```
- * <RkSwitch tintColor='blue' onTintColor='yellow' thumbTintColor='purple'
- *           value={this.state.value}
- *           onValueChange={() => this.setState({value: !this.state.value})} />
+ * <RkSwitch
+ *   tintColor='blue'
+ *   onTintColor='yellow'
+ *   thumbTintColor='purple'
+ *   value={this.state.value}
+ *   onValueChange={this.onSwitchValueChange)}
+ * />
  * ```
- *
  *
  * @example Using rkType prop
  *
  * `RkSwitch` has `rkType` prop. This prop works similar to CSS-class in web.
  * It is possible to set more than one type.
- * There is a possibility to control tint colors via rkTypes.
- * The library already contains some predefined types and also it is possible to create new ones:
+ * There is a possibility to control tint colors via `rkType`s.
+ * Available `rkType`s: `primary`, `success`, `info`, `warning`, `danger`.
  *
  * ```
- * RkTheme.setType('RkSwitch', 'mySwitch', {
- *     tintColor: 'blue',
- *     onTintColor: 'yellow',
- *     thumbTintColor: 'purple',
- *     margin: 10
- * });
-
- * <RkSwitch rkType='danger' value={this.state.value}
- *           onValueChange={() => this.setState({value: !this.state.value})} />
- * <RkSwitch rkType='mySwitch' value={this.state.value}
- *           onValueChange={() => this.setState({value: !this.state.value})} />
+ * <RkSwitch
+ *   rkType='danger'
+ *   value={this.state.value}
+ *   onValueChange={this.onSwitchValueChange}
+ * />
+ * ```
  *
+ * @example Define new rkTypes
+ *
+ * New rkTypes are defined using `setType` method of `RkTheme`.
+ *
+ * ```
+ * RkTheme.setType('RkSwitch', 'projectDefault', {
+ *   tintColor: 'blue',
+ *   onTintColor: 'yellow',
+ *   thumbTintColor: 'purple',
+ *   margin: 10,
+ * });
  * ```
  *
  * @styles Available style properties:
@@ -58,13 +78,11 @@ import { RkComponent } from '../rkComponent';
  * - `thumbTintColor` : will be converted into `thumbTintColor` prop of `Switch`
  * - ...: Any other style properties will be applied to `View` container.
  *
- *
  * @property {string} rkType - Types for component stylization
  * By default `RkSwitch` supports following types: `primary`, `warning`, `danger`, `success`, `info`
  * @property {style} style - Style for `View` container
  * @property {Switch.props} props - All `Switch` props also applied to `RkSwitch`
  */
-
 export class RkSwitch extends RkComponent {
   componentName = 'RkSwitch';
   typeMapping = {

--- a/src/components/switch/rkSwitch.ios.js
+++ b/src/components/switch/rkSwitch.ios.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Switch,
   View,
+  ViewPropTypes,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { RkComponent } from '../rkComponent';
@@ -9,7 +10,7 @@ import { RkComponent } from '../rkComponent';
 /**
  * `RkSwitch` is a component which looks like a standard iOS switch on both platforms.
  *
- * @extends RkComponent
+ * @extends React.Component
  *
  * @example Simple usage example:
  *
@@ -89,19 +90,24 @@ export class RkSwitch extends RkComponent {
     component: {},
   };
   static propTypes = {
+    rkType: RkComponent.propTypes.rkType,
     disabled: PropTypes.bool,
     onTintColor: PropTypes.string,
-    onValueChange: PropTypes.func,
     thumbTintColor: PropTypes.string,
     tintColor: PropTypes.string,
     value: PropTypes.bool,
+    onValueChange: PropTypes.func,
+    style: ViewPropTypes.style,
   };
   static defaultProps = {
+    rkType: RkComponent.defaultProps.rkType,
     disabled: false,
     onTintColor: '#53d669',
     thumbTintColor: '#ffffff',
     tintColor: '#e5e5e5',
     value: false,
+    onValueChange: (() => null),
+    style: null,
   };
 
   defineStyles(additionalTypes) {

--- a/src/components/tab/rkTabView.js
+++ b/src/components/tab/rkTabView.js
@@ -3,7 +3,9 @@ import {
   View,
   TouchableOpacity,
   ScrollView,
+  ViewPropTypes,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { RkComponent } from '../rkComponent';
 import { RkTab } from './rkTab';
@@ -11,6 +13,8 @@ import { RkText } from '../text/rkText';
 
 /**
  * `RkTabView` is a component to display tabs in your application.
+ *
+ * @extends React.Component
  *
  * @example Usage example:
  *
@@ -259,12 +263,34 @@ import { RkText } from '../text/rkText';
  * (used only when label is text)
  * @property {function} onTabChanged - Called when active tab was changed
  */
-
 export class RkTabView extends RkComponent {
+  static propTypes = {
+    rkType: RkComponent.propTypes.rkType,
+    rkTypeSelected: RkComponent.propTypes.rkType,
+    index: PropTypes.number,
+    maxVisibleTabs: PropTypes.number,
+    tabsUnderContent: PropTypes.bool,
+    onTabChanged: PropTypes.func,
+    headerContainerStyle: ViewPropTypes.style,
+    style: ViewPropTypes.style,
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node,
+    ]).isRequired,
+  };
+  static defaultProps = {
+    rkType: RkComponent.defaultProps.rkType,
+    rkTypeSelected: RkComponent.defaultProps.rkType,
+    index: 0,
+    maxVisibleTabs: undefined,
+    tabsUnderContent: false,
+    onTabChanged: (() => null),
+    style: null,
+    headerContainerStyle: null,
+  };
   static Tab = RkTab;
 
   componentName = 'RkTabView';
-
   typeMapping = {
     container: {},
     headerContainer: {},
@@ -279,14 +305,15 @@ export class RkTabView extends RkComponent {
     contentContainer: {},
   };
 
+  state = {
+    index: RkTabView.defaultProps.index,
+  };
+
   selectedType = 'selected';
 
   constructor(props) {
     super(props);
-    this.state = {
-      index: +props.index || 0,
-    };
-
+    this.state.index = props.index;
     if (this.props.rkTypeSelected) {
       this.selectedType = this.props.rkTypeSelected;
     } else {
@@ -297,11 +324,11 @@ export class RkTabView extends RkComponent {
     }
   }
 
-  onContainerLayout(e, tabsCount) {
-    const { width: layoutWidth } = e.nativeEvent.layout;
-    const tabWidth = layoutWidth / tabsCount;
-    this.setState({ tabWidth });
-  }
+  onContainerLayout = (e) => {
+    this.setState({
+      tabWidth: e.nativeEvent.layout.width / this.props.maxVisibleTabs,
+    });
+  };
 
   defineComponentStyles(selected) {
     if (selected) {
@@ -313,9 +340,7 @@ export class RkTabView extends RkComponent {
   selectTab(id) {
     if (this.state.index !== id) {
       this.setState({ index: +id });
-      if (this.props.onTabChanged && (typeof this.props.onTabChanged === 'function')) {
-        this.props.onTabChanged(id);
-      }
+      this.props.onTabChanged(id);
     }
   }
 
@@ -367,9 +392,7 @@ export class RkTabView extends RkComponent {
     };
     return (
       <ScrollView
-        onLayout={(e) => {
-          this.onContainerLayout(e, this.props.maxVisibleTabs);
-        }}
+        onLayout={this.onContainerLayout}
         scrollEnabled={scrollableHeader}
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}

--- a/src/components/text/rkText.js
+++ b/src/components/text/rkText.js
@@ -7,7 +7,7 @@ import { RkComponent } from '../rkComponent';
 /**
  * `RkText` is a component used to render text blocks
  *
- * @extends RkComponent
+ * @extends React.Component
  *
  * @example Simple usage example:
  *

--- a/src/components/textinput/rkTextInput.js
+++ b/src/components/textinput/rkTextInput.js
@@ -3,13 +3,15 @@ import {
   Text,
   TextInput,
   TouchableOpacity,
+  ViewPropTypes,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import { RkComponent } from '../rkComponent';
 
 /**
  * `RkTextInput` is a component to be used as a basic text input.
  *
- * @extends RkComponent
+ * @extends React.Component
  *
  * @example Usage sample:
  *
@@ -132,8 +134,22 @@ import { RkComponent } from '../rkComponent';
  * @property {style} labelStyle - Style applied to label
  * @property {style} inputStyle - Style applied to text input
  */
-
 export class RkTextInput extends RkComponent {
+  static propTypes = {
+    editable: PropTypes.bool,
+    label: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]),
+    style: ViewPropTypes.style,
+    inputStyle: ViewPropTypes.style,
+  };
+  static defaultProps = {
+    editable: true,
+    label: null,
+    style: null,
+    inputStyle: null,
+  };
   componentName = 'RkTextInput';
   typeMapping = {
     container: {
@@ -151,22 +167,13 @@ export class RkTextInput extends RkComponent {
     },
   };
 
-  static defaultProps = {
-    editable: true,
-  };
-
-  constructor(props) {
-    super(props);
-    this.focusInput = this.focusInput.bind(this);
-  }
-
-  focusInput() {
+  focusInput = () => {
     if (this.props.editable) {
       this.inputRef.focus();
     }
-  }
+  };
 
-  displayLabel(label, labelStyle) {
+  renderLabel(label, labelStyle) {
     if (typeof label === 'string') {
       return (
         <Text style={labelStyle} onPress={this.focusInput}>{label}</Text>
@@ -198,7 +205,7 @@ export class RkTextInput extends RkComponent {
     boxStyle.push(style);
     return (
       <TouchableOpacity activeOpacity={1} onPress={this.focusInput} style={boxStyle}>
-        {label && this.displayLabel(label, inputProps.labelStyle)}
+        {label && this.renderLabel(label, inputProps.labelStyle)}
         <TextInput
           underlineColorAndroid='transparent'
           ref={(inputValue) => {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

**Bug Fixes:**

* **rkTextInput:** non-editable rkTextInput crash on Android ([e755ce1](https://github.com/akveo/react-native-ui-kitten/commit/e755ce1))
* **rkModalImg:** more than 10 items render ([c98d45c](https://github.com/akveo/react-native-ui-kitten/commit/c98d45c))
* **rkCard:** nullable subview render ([0275291](https://github.com/akveo/react-native-ui-kitten/commit/0275291))
* **rkChoice:** antialiased render on Android ([c86d57c](https://github.com/akveo/react-native-ui-kitten/commit/c86d57c))

**Features:**

* **build:** eslint integration and project adopt ([24d268b](https://github.com/akveo/react-native-ui-kitten/commit/24d268b))
* **build:** add expo 27 and RN 0.56 support ([8c8b987](https://github.com/akveo/react-native-ui-kitten/commit/8c8b987))
* **rkSwitch:** component implementation ([08dd2df](https://github.com/akveo/react-native-ui-kitten/commit/08dd2df))
* **rkGallery:** component implementation ([2a9f652](https://github.com/akveo/react-native-ui-kitten/commit/2a9f652))
* **rkGalleryImage:** component implementation ([794b117](https://github.com/akveo/react-native-ui-kitten/commit/794b117))