### PR TITLE
fix(RkSwitch): Fix incorrect thumb animation in case if gesture was intercepted by parent view

### DIFF
--- a/src/components/switch/rkSwitch.android.js
+++ b/src/components/switch/rkSwitch.android.js
@@ -192,7 +192,7 @@ export class RkSwitch extends RkComponent {
 
   // eslint-disable-next-line arrow-body-style
   onPanResponderTerminationRequest = () => {
-    return true;
+    return false;
   };
 
   onPanResponderGrant = () => {


### PR DESCRIPTION
 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
There is thumb animation when a user starts a gesture. And if RkSwitch is included into another component with its own pan responder (like ScrollView) the animation will be not canceled if gestures will be intercepted.