### PR TITLE
fix(rkText): style prop definition. Closes #177

### DIFF
--- a/src/components/button/rkButton.js
+++ b/src/components/button/rkButton.js
@@ -141,7 +141,7 @@ import { RkComponent } from '../rkComponent';
 export class RkButton extends RkComponent {
   static propTypes = {
     style: ViewPropTypes.style,
-    contentStyle: ViewPropTypes.style,
+    contentStyle: RkText.propTypes.style,
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),
       PropTypes.node,


### PR DESCRIPTION
Replace the type of `contentStyle` from `ViewPropTypes.style` to `RkText.propTypes.style` to resolve the [issue#177](https://github.com/akveo/react-native-ui-kitten/issues/177)

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves: