### PR TITLE
fix(ui): popover visibility

### DIFF
--- a/src/framework/ui/overflowMenu/overflowMenu.component.tsx
+++ b/src/framework/ui/overflowMenu/overflowMenu.component.tsx
@@ -51,18 +51,17 @@ export class OverflowMenu extends React.Component<Props> {
 
 
   private onSelect = (event: GestureResponderEvent, index: number): void => {
-    const { visible, onSelect } = this.props;
-    // FIXME: this is due to popover renders always with the "opacity": 0,
-    //  so popover can listen events even it's "invisible"
-    if (visible && onSelect) {
-      onSelect(event, index);
+    if (this.props.onSelect) {
+      this.props.onSelect(event, index);
     }
   };
 
-  private getPopoverStyle = (style: StyleType): StyleType => ({
-    backgroundColor: style.popoverBackgroundColor,
-    borderRadius: style.borderRadius,
-  });
+  private getPopoverStyle = (style: StyleType): StyleType => {
+    return {
+      backgroundColor: style.popoverBackgroundColor,
+      borderRadius: style.borderRadius,
+    };
+  };
 
   private getMenuItemStyle = (style: StyleType, index: number): StyleType => {
     const borderRadius: number = style.itemBorderRadius;

--- a/src/framework/ui/overflowMenu/overflowMenu.spec.tsx.snap
+++ b/src/framework/ui/overflowMenu/overflowMenu.spec.tsx.snap
@@ -19,9 +19,7 @@ exports[`@overflow-menu: component checks * component renders properly 1`] = `
     onLayout={[Function]}
     style={
       Object {
-        "opacity": 0,
         "position": "absolute",
-        "zIndex": -1,
       }
     }
     tag={1}
@@ -500,9 +498,7 @@ exports[`@overflow-menu: component checks * single menu-item 1`] = `
     onLayout={[Function]}
     style={
       Object {
-        "opacity": 0,
         "position": "absolute",
-        "zIndex": -1,
       }
     }
     tag={1}


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

* Removes useless render of popover while it is invisible
* Refactors components built on `Popover`