### PR TITLE
fix(rkTextInput): Revert to overriding _focusInput method

### DIFF
--- a/src/components/textinput/rkTextInput.js
+++ b/src/components/textinput/rkTextInput.js
@@ -167,7 +167,7 @@ export class RkTextInput extends RkComponent {
     },
   };
 
-  focusInput = () => {
+  _focusInput = () => {
     if (this.props.editable) {
       this.inputRef.focus();
     }
@@ -176,7 +176,7 @@ export class RkTextInput extends RkComponent {
   renderLabel(label, labelStyle) {
     if (typeof label === 'string') {
       return (
-        <Text style={labelStyle} onPress={this.focusInput}>{label}</Text>
+        <Text style={labelStyle} onPress={this._focusInput}>{label}</Text>
       );
     }
     return React.cloneElement(label, {
@@ -205,7 +205,7 @@ export class RkTextInput extends RkComponent {
     inputProps.placeholderTextColor = placeholderColor;
     boxStyle.push(style);
     return (
-      <TouchableOpacity activeOpacity={1} onPress={this.focusInput} style={boxStyle}>
+      <TouchableOpacity activeOpacity={1} onPress={this._focusInput} style={boxStyle}>
         {label && this.renderLabel(label, inputProps.labelStyle)}
         <TextInput
           underlineColorAndroid='transparent'


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves: