### PR TITLE
fix(ui): export tab-view children props

### DIFF
--- a/src/framework/ui/index.ts
+++ b/src/framework/ui/index.ts
@@ -75,6 +75,7 @@ import {
 import {
   TabView,
   Props as TabViewProps,
+  ChildProps as TabViewChildProps,
 } from './tab/tabView.component';
 import {
   Text as TextComponent,
@@ -182,6 +183,7 @@ export {
   TabProps,
   TabBarProps,
   TabViewProps,
+  TabViewChildProps,
   TextProps,
   TooltipProps,
   ToggleProps,

--- a/src/framework/ui/tab/tabView.component.tsx
+++ b/src/framework/ui/tab/tabView.component.tsx
@@ -48,7 +48,6 @@ export class TabView extends React.Component<Props> {
 
   static defaultProps: Partial<Props> = {
     selectedIndex: 0,
-    contentWidth: Dimensions.get('window').width,
   };
 
   private viewPagerRef: React.RefObject<ViewPager> = React.createRef();


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

* Exports `TabView` `children` prop props 