### PR TITLE
add missing `>` to example code in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import { ApplicationProvider, Layout } from 'react-native-ui-kitten';
 const App = () => (
   <ApplicationProvider 
     mapping={mapping}
-    theme={lightTheme}
+    theme={lightTheme}>
     <Layout style={{flex: 1}}/>
   </ApplicationProvider>
 );


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

This is just a simple edit to the readme. 
It's just missing a `>`

When I was setting up ui-kitten, I ran into an error after copying the quick-start code.

