### PR TITLE
refactor(script): set-env script with node

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start:pg": "npm run install:pg && npm start --prefix ./src/playground",
     "start:pg:prod": "npm run env:set -- prod && npm run start:pg",
     "start:pg:dev": "npm run env:set -- dev && npm run start:pg",
-    "env:set": "./scripts/environment/set-env.sh",
+    "env:set": "node ./scripts/environment/set-env.js",
     "build": "./scripts/build/compile-ts.sh",
     "build:transform": "./scripts/build/transform-paths.sh",
     "build:dev": "npm run build -- dev && npm run build:transform -- dev",

--- a/scripts/environment/set-env.js
+++ b/scripts/environment/set-env.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const fs = require('fs');
+
+const scriptArguments = process.argv.splice(2);
+const { [0]: envArgument } = scriptArguments;
+
+const rootDir = path.resolve(__dirname, '../../');
+
+const envConfigFile = path.resolve(rootDir, `config/${envArgument}.env.js`);
+const envConfigMainFile = path.resolve(rootDir, `config/index.js`);
+
+fs.copyFileSync(envConfigFile, envConfigMainFile);
+

--- a/scripts/environment/set-env.sh
+++ b/scripts/environment/set-env.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-env=${1}
-cp ./config/${env}.env.js ./config/index.js


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Related issue: #645 
Refactors `set-env` script to node executable, which makes possible to run playground on Windows