### PR TITLE
fix(select): compare SelectOptionType by text rather than object

### DIFF
--- a/src/framework/ui/select/selection.strategy.ts
+++ b/src/framework/ui/select/selection.strategy.ts
@@ -32,7 +32,7 @@ export class MultiSelectStrategy implements SelectionStrategy {
   private selectDefaultOption(option: SelectOptionType): void {
     const optionAlreadyExist: boolean = this.selectedOption
       .some((item: SelectOptionType) => {
-        return item === option;
+        return item.text === option.text;
       });
     if (optionAlreadyExist) {
       this.removeOption(option);
@@ -87,7 +87,7 @@ export class MultiSelectStrategy implements SelectionStrategy {
   private removeOption(option: SelectOptionType): void {
     const index: number = this.selectedOption
       .findIndex((item: SelectOptionType) => {
-        return item === option;
+        return item.text === option.text;
       });
     if (index !== -1) {
       this.selectedOption.splice(index, 1);


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

When utilizing the multiSelect Select component, it is not possible to default a value, because the comparison is attempting to use an Object Equality.

For example within the documentation,

```
state = {
    selectedOption: [],
  };
```

change to:

```
state = {
    selectedOption: [{ text: 'Option 1' }],
  };
```
will put 'Option 1' in the input field, but when opening the selector, the value is not checked. If pressed again, it will duplicate the option.