### PR TITLE
bug (ui):  Fix Calendar Navigation

### DIFF
--- a/src/framework/ui/calendar/baseCalendar.component.tsx
+++ b/src/framework/ui/calendar/baseCalendar.component.tsx
@@ -174,20 +174,22 @@ export abstract class BaseCalendarComponent<D, P> extends React.Component<BaseCa
   };
 
   private onHeaderNavigationLeftPress = (): void => {
-    const pagerRef: React.RefObject<CalendarPager<D>> = this.getCurrentPagerRef();
-
-    pagerRef.current.scrollToIndex({
-      index: pagerRef.current.props.selectedIndex - 1,
-      animated: true,
+    const newDate = this.dateService.createDate(
+      this.dateService.getYear(this.state.visibleDate),
+      this.dateService.getMonth(this.state.visibleDate) - 1,
+      this.dateService.getDate(this.state.visibleDate));
+    this.setState({
+      visibleDate: newDate,
     });
   };
 
   private onHeaderNavigationRightPress = (): void => {
-    const pagerRef: React.RefObject<CalendarPager<D>> = this.getCurrentPagerRef();
-
-    pagerRef.current.scrollToIndex({
-      index: pagerRef.current.props.selectedIndex + 1,
-      animated: true,
+    const newDate = this.dateService.createDate(
+      this.dateService.getYear(this.state.visibleDate),
+      this.dateService.getMonth(this.state.visibleDate) + 1,
+      this.dateService.getDate(this.state.visibleDate));
+    this.setState({
+      visibleDate: newDate,
     });
   };
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
Currently the left / right navigation buttons on the "Calendar" component do not update the Calendar header.  

https://github.com/akveo/react-native-ui-kitten/issues/713

##  Solution
I use the `visibleDate` state variable on `baseCalendar` instead of invoking the `scrollToIndex` function on `calendarPager`.

## Problem
When calling the function directly, only the inner child of `baseCalendar` is updated:  `viewPager`.  This leaves the `visibleDate` state variable unchanged, which is what drives the header and other children of `baseCalendar`.

##  Next Steps
This may help resolve the left / right navigation problem, but there are at least two remaining problems:
1.  The header does not change properly at year boundaries.
2.  Swiping does not work as expected.  This is because it's still only updating the internal component.  To fix this, one idea is to pass a callback, enabling `viewPager` to inform its parents when it changes:  https://github.com/akveo/react-native-ui-kitten/issues/712