### PR TITLE
Fixes a misuse of createRef

### DIFF
--- a/src/framework/ui/popover/measure.component.tsx
+++ b/src/framework/ui/popover/measure.component.tsx
@@ -4,7 +4,9 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-import React from 'react';
+import React, {
+  useRef,
+} from 'react';
 import {
   findNodeHandle,
   UIManager,
@@ -54,7 +56,7 @@ export interface MeasureNodeProps {
  */
 export const MeasureElement = (props: MeasureElementProps): MeasuringElement => {
 
-  const ref: React.RefObject<any> = React.createRef();
+  const ref: React.RefObject<any> = useRef();
 
   const { children, onResult } = props;
 


### PR DESCRIPTION
React.createRef cannot be used in functional components. Doing so here causes ref.current to sometimes be `null` when `measureSelf` is called (i.e. if a rerender has happened).

As stated in the React docs: "You may not use the ref attribute on function components because they don’t have instances." (https://reactjs.org/docs/refs-and-the-dom.html)

The solution proposed here is to use the `useRef` hook, which can be used in a functional component.

(I have tested this code change in my project, but have not run formal tests.)