### PR TITLE
fix issue #669 - invalid prop `dispatch` on <div> tag for React Native Web

### DIFF
--- a/src/components/ui/text/text.component.tsx
+++ b/src/components/ui/text/text.component.tsx
@@ -59,7 +59,7 @@ export class TextComponent extends React.Component<TextProps> {
   static styledComponentName: string = 'Text';
 
   public render(): React.ReactElement<RNTextProps> {
-    const { themedStyle, style, ...derivedProps } = this.props;
+    const { themedStyle, style, dispatch, ...derivedProps } = this.props;
 
     return (
       <RNText


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
Whenever using a Button and a Text component with ReactJS v16..0 even though elements are rendered and they work as expected an error message is displayed with the text:

> Warning: Invalid value for prop `dispatch` on <div> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://fb.me/react-attribute-behavior