### PR TITLE
test(components): fix range-date-picker spec

### DIFF
--- a/src/components/ui/calendar/rangeCalendar.spec.tsx
+++ b/src/components/ui/calendar/rangeCalendar.spec.tsx
@@ -18,7 +18,6 @@ import { CalendarRange } from '@kitten/ui/calendar/type';
 jest.useFakeTimers();
 
 const now: Date = new Date();
-const today = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
 
 interface State {
   range: CalendarRange<Date>;
@@ -68,11 +67,11 @@ describe('@range-calendar: component checks', () => {
 
   it('* range selected works properly', () => {
     const expectedStartDate: Date = new Date(now.getFullYear(), now.getMonth(), 11);
-    const expectedEndDate: Date = new Date(now.getFullYear(), now.getMonth(), 26);
+    const expectedEndDate: Date = new Date(now.getFullYear(), now.getMonth(), 15);
     const application: RenderAPI = render(<TestApplication/>);
 
     fireEvent.press(application.getAllByText('11')[0]);
-    fireEvent.press(application.getAllByText('26')[0]);
+    fireEvent.press(application.getAllByText('15')[0]);
     const { range } = application.getByType(RangeCalendar).props;
 
     expect(range.startDate.toString()).toBe(expectedStartDate.toString());
@@ -84,7 +83,7 @@ describe('@range-calendar: component checks', () => {
     const application: RenderAPI = render(<TestApplication/>);
 
     fireEvent.press(application.getAllByText('11')[0]);
-    fireEvent.press(application.getAllByText('26')[0]);
+    fireEvent.press(application.getAllByText('15')[0]);
     fireEvent.press(application.getAllByText('19')[0]);
     const { range } = application.getByType(RangeCalendar).props;
 
@@ -97,7 +96,7 @@ describe('@range-calendar: component checks', () => {
     const application: RenderAPI = render(<TestApplication/>);
 
     fireEvent.press(application.getAllByText('11')[0]);
-    fireEvent.press(application.getAllByText('26')[0]);
+    fireEvent.press(application.getAllByText('15')[0]);
     fireEvent.press(application.getAllByText('8')[0]);
     const { range } = application.getByType(RangeCalendar).props;
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Modifies Range Calendar spec so that there is no way to perform date selection from previous month during the test case