### PR TITLE
feat(components): add styles property to ApplicationProvider

### DIFF
--- a/src/components/theme/application/applicationProvider.component.tsx
+++ b/src/components/theme/application/applicationProvider.component.tsx
@@ -7,11 +7,7 @@
 import React from 'react';
 import merge from 'lodash.merge';
 import { SchemaProcessor } from '@eva-design/processor';
-import {
-  CustomSchemaType,
-  SchemaType,
-  ThemeStyleType,
-} from '@eva-design/dss';
+import { CustomSchemaType, SchemaType, ThemeStyleType } from '@eva-design/dss';
 import { StyleProvider } from '../style/styleProvider.component';
 import { ThemeProviderProps } from '../theme/themeProvider.component';
 import { ModalPanel } from '../modal/modalPanel.component';
@@ -19,6 +15,7 @@ import { ModalPanel } from '../modal/modalPanel.component';
 interface ComponentProps {
   mapping: SchemaType;
   customMapping?: CustomSchemaType;
+  styles?: ThemeStyleType;
 }
 
 export type ApplicationProviderProps = ComponentProps & ThemeProviderProps;
@@ -38,13 +35,16 @@ interface State {
  * @extends React.Component
  *
  * @property {SchemaType} mapping - Determines the mapping for basic components.
- * This is designed to be provided by developers team and can be imported from npm package (e.g. `@eva-design/eva`).
+ * This is designed to be provided from any `@eva-design/*` package (e.g. `@eva-design/eva`)
  *
- * @property {CustomSchemaType} customMapping - Determines the customization mapping.
+ * @property {CustomSchemaType} customMapping - Determines the customized mapping.
  * This is merged with `mapping` property and designed to be used components customization.
  *
  * @property {ThemeType} theme - Determines the theme for basic components.
  * This is designed to be provided by developers team and can be imported from npm package (e.g. `@eva-design/eva`).
+ *
+ * @property {ThemeStyleType} styles - Determines the compiled styles.
+ * If ApplicationProvider receives this property, it will replace runtime mapping processing.
  *
  * @property {ReactNode} children - Determines application root component.
  *
@@ -73,20 +73,22 @@ interface State {
  */
 export class ApplicationProvider extends React.Component<ApplicationProviderProps, State> {
 
+  public state: State = {
+    styles: this.props.styles,
+  };
+
   private schemaProcessor: SchemaProcessor = new SchemaProcessor();
 
   constructor(props: ApplicationProviderProps) {
     super(props);
-    const { mapping, customMapping } = this.props;
 
-    const styles: ThemeStyleType = this.createStyles(mapping, customMapping);
-
-    this.state = { styles };
+    if (!this.state.styles) {
+      this.state.styles = this.createStyles(props.mapping, props.customMapping);
+    }
   }
 
   private createStyles = (mapping: SchemaType, custom: CustomSchemaType): ThemeStyleType => {
     const customizedMapping: SchemaType = merge({}, mapping, custom);
-
     return this.schemaProcessor.process(customizedMapping);
   };
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Adds `styles` property to ApplicationProvider.
- It **must** represent a styles generated with processing of eva mapping
- In case no `styles` provided, the mapping will be processed during the runtime
- Gives users the ability to resolve issue with large mapping customization #855 and React Native Navigation #613
- Could be improved with [@eva-design/cli](https://github.com/eva-design/eva/pull/65) to make it in developer-friendly way

As a result, this improves ApplicationProvider loading for at least 1.398 seconds (iPhone 11 Pro, no custom mapping). And for even more, if there is custom mapping :)

<hr>

#### Integration

As a user I should make the following steps to make it work in a developer-friendly way:

1. `yarn add -D @eva-design/cli`
2. Add `eva.config.js` to the project root
```js
module.exports = {
  evaPackage: '@eva-design/eva', // Required
  customMappingPath: './src/custom-mapping.json' // Optional
};
```
3. `yarn eva bootstrap`
4. Modify props of application provider
```diff
- import { mapping, light } from '@eva-design/eva';
+ import * as eva from '@eva-design/eva'; 
- import { customMapping } from './custom-mapping.js'

export default = () => (
- <ApplicationProvider mapping={mapping} theme={light} />
+ <ApplicationProvider {...eva} theme={theme} />
);
```

#### Limitations

When using custom mapping, `yarn eva bootstrap` should be called whenever custom mapping is changed to re-generate styles, but [I guess we can handle it during the build time](https://github.com/react-native-community/cli/issues/972).

[How `eva bootstrap` works](https://github.com/eva-design/eva/blob/29b2911f62ea65e9eaea832f25b3ba4804220244/packages/cli/services/bootstrap.service.ts#L17)