### PR TITLE
fix(components): Explicit useNativeDriver for tabIndicator for React Native 0.62.0

### DIFF
--- a/src/components/ui/support/components/tabIndicator.component.tsx
+++ b/src/components/ui/support/components/tabIndicator.component.tsx
@@ -87,6 +87,7 @@ export class TabIndicator extends React.Component<TabIndicatorProps> {
       toValue: I18nLayoutService.select(params.offset, -params.offset),
       duration: animationDuration,
       easing: Easing.linear,
+      useNativeDriver: true,
     });
   };
 


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

In React Native 0.62.0, [we need to explicitly set useNativeDriver](https://github.com/facebook/react-native/commit/5876052615f4858ed5fc32fa3da9b64695974238) in animations (or a warning is issued).  This fixes it for TabIndicator.  There may be other places where it's required, but I'm unsure about whether it should be true/false in those other locations.