### PR TITLE
docs(topNavigation): fix typo for accesoryRight

### DIFF
--- a/src/components/ui/topNavigation/topNavigation.component.tsx
+++ b/src/components/ui/topNavigation/topNavigation.component.tsx
@@ -55,7 +55,7 @@ type AlignmentProp = 'start' | 'center';
  * @property {() => ReactElement} accessoryLeft - Function component
  * to render to the left edge the top navigation.
  *
- * @property {() => ReactElement} accessoryLeft - Function component
+ * @property {() => ReactElement} accessoryRight - Function component
  * to render to the right edge the top navigation.
  *
  * @property {string} appearance - Appearance of the component.


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
In the second property it should be **accesoryRight** but it says **accesoryLeft** instead thus repeating **accesoryLeft** twice.
Before:
```typescript
* @property {() => ReactElement} accessoryLeft - Function component
* to render to the left edge the top navigation.
*
* @property {() => ReactElement} accessoryLeft - Function component
* to render to the right edge the top navigation.
```
After:
```typescript
* @property {() => ReactElement} accessoryLeft - Function component
* to render to the left edge the top navigation.
*
* @property {() => ReactElement} accessoryRight - Function component
* to render to the right edge the top navigation.
```