### PR TITLE
feat(icon): add null as a valid animation 

### DIFF
--- a/src/components/ui/icon/icon.component.tsx
+++ b/src/components/ui/icon/icon.component.tsx
@@ -27,7 +27,7 @@ type WrappedElementProps = any;
 export type IconProps<T = WrappedElementProps> = T & {
   name: string;
   pack?: string;
-  animation?: keyof IconAnimationRegistry;
+  animation?: keyof IconAnimationRegistry | null;
   animationConfig?: AnimationConfig;
 };
 
@@ -47,7 +47,7 @@ export type IconElement<T = WrappedElementProps> = React.ReactElement<IconProps<
  * @property {string} pack - A name of icon pack registered in IconRegistry that is able to provide
  * an icon for a given name.
  *
- * @property {string} animation - Animation name. Can be `zoom`, `pulse` and `shake`.
+ * @property {string} animation - Animation name. Can be `zoom`, `pulse`, `shake` or null.
  * Defaults to *zoom*.
  *
  * @property {AnimationConfig} animationConfig - Animation config.
@@ -82,7 +82,7 @@ export class Icon<T> extends React.Component<IconProps<T>> {
     animation: 'zoom',
   };
 
-  private readonly animation: IconAnimation;
+  private readonly animation: IconAnimation | null;
 
   constructor(props: IconProps<T>) {
     super(props);
@@ -90,24 +90,29 @@ export class Icon<T> extends React.Component<IconProps<T>> {
   }
 
   public componentWillUnmount(): void {
-    this.animation.release();
+    this.animation?.release();
   }
 
   public startAnimation = (callback?: Animated.EndCallback): void => {
-    this.animation.start(callback);
+    this.animation?.start(callback);
   };
 
   public stopAnimation = (): void => {
-    this.animation.stop();
+    this.animation?.stop();
   };
 
   public render(): React.ReactElement<ViewProps> {
     const { name, pack, animation, ...iconProps } = this.props;
     const registeredIcon: RegisteredIcon<T> = IconRegistryService.getIcon(name, pack);
+    const iconElement = registeredIcon.icon.toReactElement(iconProps as T);
+
+    if (!this.animation) {
+      return iconElement;
+    }
 
     return (
       <Animated.View {...this.animation.toProps()}>
-        {registeredIcon.icon.toReactElement(iconProps as T)}
+        {iconElement}
       </Animated.View>
     );
   }

--- a/src/components/ui/icon/icon.spec.tsx
+++ b/src/components/ui/icon/icon.spec.tsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import {
+  Animated,
   View,
   ViewProps,
 } from 'react-native';
@@ -111,7 +112,7 @@ describe('@icon: component checks', () => {
     }).toThrowError();
   });
 
-  it('* should throw while rendering icon from not registered pack', () => {
+  it('should throw while rendering icon from not registered pack', () => {
     expect(() => {
       render(
         <Icon name='home' pack='not-registered-pack'/>,
@@ -119,4 +120,11 @@ describe('@icon: component checks', () => {
     }).toThrowError();
   });
 
+  it('should render without an animation if animation is null', () => {
+    const component = render(
+      <Icon name='home' animation={null} />,
+    );
+
+    expect(() => component.UNSAFE_getByType(Animated.View)).toThrow();
+  });
 });

--- a/src/components/ui/icon/iconAnimation.ts
+++ b/src/components/ui/icon/iconAnimation.ts
@@ -21,7 +21,7 @@ export interface IconAnimationRegistry {
   shake: IconAnimation;
 }
 
-export function getIconAnimation(animation?: keyof IconAnimationRegistry, config?: AnimationConfig): IconAnimation {
+export function getIconAnimation(animation?: keyof IconAnimationRegistry | null, config?: AnimationConfig): IconAnimation | null {
   switch (animation) {
     case 'zoom':
       return new ZoomAnimation(config);
@@ -29,5 +29,7 @@ export function getIconAnimation(animation?: keyof IconAnimationRegistry, config
       return new PulseAnimation(config);
     case 'shake':
       return new ShakeAnimation(config);
+    default:
+      return null;
   }
 }

--- a/src/showcases/components/icon/iconAnimation.component.tsx
+++ b/src/showcases/components/icon/iconAnimation.component.tsx
@@ -8,6 +8,7 @@ export const IconAnimationShowcase = () => {
   const pulseIconRef = React.useRef();
   const shakeIconRef = React.useRef();
   const infiniteAnimationIconRef = React.useRef();
+  const noAnimationIconRef = React.useRef();
 
   React.useEffect(() => {
     infiniteAnimationIconRef.current.startAnimation();
@@ -50,6 +51,15 @@ export const IconAnimationShowcase = () => {
     />
   );
 
+  const renderNoAnimationIcon = (props) => (
+    <Icon
+      {...props}
+      ref={noAnimationIconRef}
+      animation={null}
+      name='eye'
+    />
+  );
+
   return (
     <Layout style={styles.container} level='1'>
 
@@ -84,6 +94,14 @@ export const IconAnimationShowcase = () => {
         style={styles.button}
         accessoryRight={renderInfiniteAnimationIcon}>
         INFINITE
+      </Button>
+
+      <Button
+        appearance='ghost'
+        status='warning'
+        style={styles.button}
+        accessoryRight={renderNoAnimationIcon}>
+        NO ANIMATION
       </Button>
 
     </Layout>


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

In our app we render a lot lists with hundreds or thousands of items. Each list item has an icon, but list rendering is slowed down by the icons animating. We don't care much for the animation and would like an easy way to disable the animation.