### PR TITLE
feat(components): Add RenderType type

### DIFF
--- a/src/components/devsupport/components/falsyFC/falsyFC.component.tsx
+++ b/src/components/devsupport/components/falsyFC/falsyFC.component.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 export type RenderProp<Props = {}> = (props?: Props) => React.ReactElement;
 
+export type RenderType<Props = {}> = RenderProp<Props> | React.ReactElement
+
 export type FalsyFCProps<Props = {}> = Props & {
-  component?: RenderProp<Props>;
+  component?: RenderType<Props>;
   fallback?: React.ReactElement;
 };
 
@@ -16,7 +18,7 @@ export type FalsyFCProps<Props = {}> = Props & {
  * If it is a function, will call it with props passed to this component.
  * Otherwise, will return null.
  *
- * @property {RenderProp} component - Function component to be rendered.
+ * @property {RenderType} component - Function component to be rendered.
  * @property {React.ReactElement} fallback - Element to render if children is null or undefined.
  *
  * @example Will render nothing.
@@ -43,6 +45,10 @@ export class FalsyFC<Props = {}> extends React.Component<FalsyFCProps<Props>> {
       return fallback || null;
     }
 
-    return React.createElement(component, props as Props);
+    if (React.isValidElement(component)) {
+      return React.cloneElement(component, props);
+    }
+
+    return React.createElement(component as RenderProp<Props>, props as Props);
   }
 }

--- a/src/components/devsupport/components/falsyFC/falsyFC.spec.tsx
+++ b/src/components/devsupport/components/falsyFC/falsyFC.spec.tsx
@@ -71,3 +71,23 @@ it('should be able to render components with hooks', function () {
 
   expect(textComponent).toBeTruthy();
 });
+
+it('should be able to render valid element', function () {
+  const ComponentWithHooks = (props) => {
+    return <Text {...props}>I love Babel</Text>;
+  };
+
+  const component = render(
+    <FalsyFC
+      style={{ color: 'red' }}
+      component={<ComponentWithHooks />}
+    />,
+  );
+
+  const textComponent = component.getByText('I love Babel');
+  expect(textComponent).toBeTruthy();
+  expect(textComponent.props.style).toEqual({
+    color: 'red',
+  });
+});
+

--- a/src/components/devsupport/components/falsyText/falsyText.component.tsx
+++ b/src/components/devsupport/components/falsyText/falsyText.component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { RenderProp } from '../falsyFC/falsyFC.component';
+import { RenderType } from '../falsyFC/falsyFC.component';
 import {
   Text,
   TextProps,
 } from '../../../ui/text/text.component';
 
 export interface FalsyTextProps extends Omit<TextProps, 'children'> {
-  component?: RenderProp<TextProps> | React.ReactText;
+  component?: RenderType<TextProps> | React.ReactText;
 }
 
 /**
@@ -55,6 +55,10 @@ export class FalsyText extends React.Component<FalsyTextProps> {
 
     if (!component) {
       return null;
+    }
+
+    if (React.isValidElement(component)) {
+      return React.cloneElement(component, textProps as TextProps);
     }
 
     if (typeof component === 'function') {

--- a/src/components/devsupport/components/measure/measure.component.tsx
+++ b/src/components/devsupport/components/measure/measure.component.tsx
@@ -60,15 +60,15 @@ export const MeasureElement = (props: MeasureElementProps): MeasuringElement => 
     return bindToWindow(boundFrame, window);
   };
 
-  const onUIManagerMeasure = (x: number, y: number, w: number, h: number): void => {
-    const frame: Frame = bindToWindow(new Frame(x, y, w, h), Frame.window());
-    props.onMeasure(frame);
-  };
+  const measureSelf = React.useCallback((): void => {
+    const onUIManagerMeasure = (x: number, y: number, w: number, h: number): void => {
+      const frame: Frame = bindToWindow(new Frame(x, y, w, h), Frame.window());
+      props.onMeasure(frame);
+    };
 
-  const measureSelf = (): void => {
     const node: number = findNodeHandle(ref.current);
     UIManager.measureInWindow(node, onUIManagerMeasure);
-  };
+  }, [props.onMeasure]);
 
   if (props.force) {
     measureSelf();

--- a/src/components/devsupport/index.ts
+++ b/src/components/devsupport/index.ts
@@ -1,6 +1,7 @@
 export {
   FalsyFC,
   RenderProp,
+  RenderType,
 } from './components/falsyFC/falsyFC.component';
 export { FalsyText } from './components/falsyText/falsyText.component';
 export {

--- a/src/components/ui/autocomplete/autocomplete.component.tsx
+++ b/src/components/ui/autocomplete/autocomplete.component.tsx
@@ -208,7 +208,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, State> {
         placement={placement}
         visible={this.state.listVisible}
         fullWidth={true}
-        anchor={() => this.renderInputElement(inputProps)}
+        anchor={this.renderInputElement(inputProps)}
         onBackdropPress={this.onBackdropPress}>
         <List
           style={styles.list}

--- a/src/components/ui/bottomNavigation/bottomNavigationTab.component.tsx
+++ b/src/components/ui/bottomNavigation/bottomNavigationTab.component.tsx
@@ -14,7 +14,7 @@ import {
 import {
   FalsyFC,
   FalsyText,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -33,8 +33,8 @@ type BottomNavigationTabStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 export interface BottomNavigationTabProps extends TouchableWebProps, BottomNavigationTabStyledProps {
-  title?: RenderProp<TextProps> | React.ReactText;
-  icon?: RenderProp<Partial<ImageProps>>;
+  title?: RenderType<TextProps> | React.ReactText;
+  icon?: RenderType<Partial<ImageProps>>;
   selected?: boolean;
   onSelect?: (selected: boolean) => void;
 }

--- a/src/components/ui/button/button.component.tsx
+++ b/src/components/ui/button/button.component.tsx
@@ -17,7 +17,7 @@ import {
   EvaStatus,
   FalsyFC,
   FalsyText,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -36,9 +36,9 @@ type ButtonStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 export interface ButtonProps extends TouchableWebProps, ButtonStyledProps {
-  children?: RenderProp<TextProps> | React.ReactText;
-  accessoryLeft?: RenderProp<Partial<ImageProps>>;
-  accessoryRight?: RenderProp<Partial<ImageProps>>;
+  children?: RenderType<TextProps> | React.ReactText;
+  accessoryLeft?: RenderType<Partial<ImageProps>>;
+  accessoryRight?: RenderType<Partial<ImageProps>>;
   status?: EvaStatus;
   size?: EvaSize;
 }

--- a/src/components/ui/card/card.component.tsx
+++ b/src/components/ui/card/card.component.tsx
@@ -14,7 +14,7 @@ import {
 import {
   EvaStatus,
   FalsyFC,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -34,9 +34,9 @@ type CardStyledProps = Overwrite<StyledComponentProps, {
 
 export interface CardProps extends TouchableWebProps, CardStyledProps {
   children?: React.ReactNode;
-  header?: RenderProp<ViewProps>;
-  footer?: RenderProp<ViewProps>;
-  accent?: RenderProp<ViewProps>;
+  header?: RenderType<ViewProps>;
+  footer?: RenderType<ViewProps>;
+  accent?: RenderType<ViewProps>;
   status?: EvaStatus;
 }
 

--- a/src/components/ui/checkbox/checkbox.component.tsx
+++ b/src/components/ui/checkbox/checkbox.component.tsx
@@ -16,7 +16,7 @@ import {
 import {
   EvaStatus,
   FalsyText,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -43,7 +43,7 @@ type CheckBoxStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 export interface CheckBoxProps extends TouchableWebProps, CheckBoxStyledProps {
-  children?: RenderProp<TextProps> | React.ReactText;
+  children?: RenderType<TextProps> | React.ReactText;
   checked?: boolean;
   onChange?: (checked: boolean, indeterminate: boolean) => void;
   indeterminate?: boolean;

--- a/src/components/ui/datepicker/baseDatepicker.component.tsx
+++ b/src/components/ui/datepicker/baseDatepicker.component.tsx
@@ -268,7 +268,7 @@ export abstract class BaseDatepickerComponent<P, D = Date> extends React.Compone
           backdropStyle={backdropStyle}
           placement={placement}
           visible={this.state.visible}
-          anchor={() => this.renderInputElement(touchableProps, evaStyle)}
+          anchor={this.renderInputElement(touchableProps, evaStyle)}
           onBackdropPress={this.setPickerInvisible}>
           {this.renderCalendar()}
         </Popover>

--- a/src/components/ui/datepicker/baseDatepicker.component.tsx
+++ b/src/components/ui/datepicker/baseDatepicker.component.tsx
@@ -20,7 +20,7 @@ import {
   EvaStatus,
   FalsyFC,
   FalsyText,
-  RenderProp,
+  RenderType,
   TouchableWithoutFeedback,
 } from '../../devsupport';
 import {
@@ -44,14 +44,14 @@ export interface BaseDatepickerProps<D = Date> extends StyledComponentProps,
   BaseCalendarProps<D> {
 
   controlStyle?: StyleProp<ViewStyle>;
-  label?: RenderProp<TextProps> | React.ReactText;
-  caption?: RenderProp<TextProps> | React.ReactText;
-  captionIcon?: RenderProp<Partial<ImageProps>>;
-  accessoryLeft?: RenderProp<Partial<ImageProps>>;
-  accessoryRight?: RenderProp<Partial<ImageProps>>;
+  label?: RenderType<TextProps> | React.ReactText;
+  caption?: RenderType<TextProps> | React.ReactText;
+  captionIcon?: RenderType<Partial<ImageProps>>;
+  accessoryLeft?: RenderType<Partial<ImageProps>>;
+  accessoryRight?: RenderType<Partial<ImageProps>>;
   status?: EvaStatus;
   size?: EvaInputSize;
-  placeholder?: RenderProp<TextProps> | React.ReactText;
+  placeholder?: RenderType<TextProps> | React.ReactText;
   placement?: PopoverPlacement | string;
   backdropStyle?: StyleProp<ViewStyle>;
   onFocus?: () => void;
@@ -98,7 +98,7 @@ export abstract class BaseDatepickerComponent<P, D = Date> extends React.Compone
 
   public abstract clear(): void;
 
-  protected abstract getComponentTitle(): RenderProp<TextProps> | React.ReactText;
+  protected abstract getComponentTitle(): RenderType<TextProps> | React.ReactText;
 
   protected abstract renderCalendar(): CalendarElement<D> | RangeCalendarElement<D>;
 

--- a/src/components/ui/datepicker/datepicker.component.tsx
+++ b/src/components/ui/datepicker/datepicker.component.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { RenderProp } from '../../devsupport';
+import { RenderType } from '../../devsupport';
 import { styled } from '../../theme';
 import {
   BaseDatepickerComponent,
@@ -209,7 +209,7 @@ export class Datepicker<D = Date> extends BaseDatepickerComponent<DatepickerProp
 
   // BaseDatepickerComponent
 
-  protected getComponentTitle(): RenderProp<TextProps> | React.ReactText {
+  protected getComponentTitle(): RenderType<TextProps> | React.ReactText {
     if (this.props.date) {
       return this.props.dateService.format(this.props.date, null);
     } else {

--- a/src/components/ui/datepicker/rangeDatepicker.component.tsx
+++ b/src/components/ui/datepicker/rangeDatepicker.component.tsx
@@ -15,7 +15,7 @@ import {
   RangeCalendarElement,
   RangeCalendarProps,
 } from '../calendar/rangeCalendar.component';
-import { RenderProp } from '@ui-kitten/components/devsupport';
+import { RenderType } from '@ui-kitten/components/devsupport';
 import { TextProps } from '@ui-kitten/components';
 
 export type RangeDatepickerProps<D = Date> = BaseDatepickerProps<D> & RangeCalendarProps<D>;
@@ -161,7 +161,7 @@ export class RangeDatepicker<D = Date> extends BaseDatepickerComponent<RangeDate
 
   // BaseDatepickerComponent
 
-  protected getComponentTitle(): RenderProp<TextProps> | React.ReactText {
+  protected getComponentTitle(): RenderType<TextProps> | React.ReactText {
     const { startDate, endDate } = this.props.range;
 
     if (startDate || endDate) {

--- a/src/components/ui/drawer/drawer.component.tsx
+++ b/src/components/ui/drawer/drawer.component.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { ViewProps } from 'react-native';
 import {
   FalsyFC,
-  RenderProp,
+  RenderType,
   Overwrite,
 } from '../../devsupport';
 import {
@@ -26,8 +26,8 @@ type DrawerStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 export interface DrawerProps extends MenuProps, DrawerStyledProps {
-  header?: RenderProp<ViewProps>;
-  footer?: RenderProp<ViewProps>;
+  header?: RenderType<ViewProps>;
+  footer?: RenderType<ViewProps>;
 }
 
 export type DrawerElement = React.ReactElement<DrawerProps>;

--- a/src/components/ui/input/input.component.tsx
+++ b/src/components/ui/input/input.component.tsx
@@ -26,7 +26,7 @@ import {
   FalsyText,
   FlexStyleProps,
   PropsService,
-  RenderProp,
+  RenderType,
   WebEventResponder,
   WebEventResponderCallbacks,
   WebEventResponderInstance,
@@ -48,11 +48,11 @@ export interface InputProps extends TextInputProps, InputStyledProps {
   status?: EvaStatus;
   size?: EvaSize;
   disabled?: boolean;
-  label?: RenderProp<TextProps> | React.ReactText;
-  caption?: RenderProp<TextProps> | React.ReactText;
-  captionIcon?: RenderProp<Partial<ImageProps>>;
-  accessoryLeft?: RenderProp<Partial<ImageProps>>;
-  accessoryRight?: RenderProp<Partial<ImageProps>>;
+  label?: RenderType<TextProps> | React.ReactText;
+  caption?: RenderType<TextProps> | React.ReactText;
+  captionIcon?: RenderType<Partial<ImageProps>>;
+  accessoryLeft?: RenderType<Partial<ImageProps>>;
+  accessoryRight?: RenderType<Partial<ImageProps>>;
   textStyle?: StyleProp<TextStyle>;
 }
 

--- a/src/components/ui/list/listItem.component.tsx
+++ b/src/components/ui/list/listItem.component.tsx
@@ -16,7 +16,7 @@ import {
 import {
   FalsyFC,
   FalsyText,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -35,10 +35,10 @@ type ListItemStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 export interface ListItemProps extends TouchableWebProps, ListItemStyledProps {
-  title?: RenderProp<TextProps> | React.ReactText;
-  description?: RenderProp<TextProps> | React.ReactText;
-  accessoryLeft?: RenderProp<Partial<ImageProps>>;
-  accessoryRight?: RenderProp<ViewProps>;
+  title?: RenderType<TextProps> | React.ReactText;
+  description?: RenderType<TextProps> | React.ReactText;
+  accessoryLeft?: RenderType<Partial<ImageProps>>;
+  accessoryRight?: RenderType<ViewProps>;
   children?: React.ReactNode;
 }
 

--- a/src/components/ui/menu/menuItem.component.tsx
+++ b/src/components/ui/menu/menuItem.component.tsx
@@ -17,7 +17,7 @@ import {
   FalsyFC,
   FalsyText,
   PropsService,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebProps,
   Overwrite,
@@ -40,9 +40,9 @@ type TouchableMenuItemProps = Overwrite<TouchableWebProps, {
 }>;
 
 export interface MenuItemProps extends TouchableMenuItemProps, MenuItemStyledProps {
-  title?: RenderProp<TextProps> | React.ReactText;
-  accessoryLeft?: RenderProp<Partial<ImageProps>>;
-  accessoryRight?: RenderProp<Partial<ImageProps>>;
+  title?: RenderType<TextProps> | React.ReactText;
+  accessoryLeft?: RenderType<Partial<ImageProps>>;
+  accessoryRight?: RenderType<Partial<ImageProps>>;
   selected?: boolean;
   descriptor?: MenuItemDescriptor;
 }

--- a/src/components/ui/popover/popover.component.tsx
+++ b/src/components/ui/popover/popover.component.tsx
@@ -7,11 +7,12 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import {
+  FalsyFC,
   Frame,
   MeasureElement,
   MeasuringElement,
   Point,
-  RenderProp,
+  RenderType,
   Overwrite,
 } from '../../devsupport';
 import { ModalService } from '../../theme';
@@ -33,7 +34,7 @@ type PopoverModalProps = Overwrite<ModalProps, {
 }>;
 
 export interface PopoverProps extends PopoverViewProps, PopoverModalProps {
-  anchor: RenderProp;
+  anchor: RenderType;
   fullWidth?: boolean;
 }
 
@@ -211,7 +212,7 @@ export class Popover extends React.Component<PopoverProps, State> {
       <MeasureElement
         force={this.state.forceMeasure}
         onMeasure={this.onChildMeasure}>
-        {this.props.anchor()}
+        <FalsyFC component={this.props.anchor} />
       </MeasureElement>
     );
   }

--- a/src/components/ui/popover/popover.component.tsx
+++ b/src/components/ui/popover/popover.component.tsx
@@ -12,8 +12,8 @@ import {
   MeasureElement,
   MeasuringElement,
   Point,
-  RenderType,
   Overwrite,
+  RenderType,
 } from '../../devsupport';
 import { ModalService } from '../../theme';
 import { ModalProps } from '../modal/modal.component';

--- a/src/components/ui/popover/popover.spec.tsx
+++ b/src/components/ui/popover/popover.spec.tsx
@@ -78,7 +78,7 @@ describe('@popover: component checks', () => {
         <Popover
           ref={ref}
           visible={visible}
-          anchor={AnchorButton}
+          anchor={AnchorButton()}
           {...props}>
           <Text>I love Babel</Text>
         </Popover>

--- a/src/components/ui/radio/radio.component.tsx
+++ b/src/components/ui/radio/radio.component.tsx
@@ -15,7 +15,7 @@ import {
 import {
   EvaStatus,
   FalsyText,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -34,7 +34,7 @@ type RadioStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 export interface RadioProps extends TouchableWebProps, RadioStyledProps {
-  children?: RenderProp<TextProps> | React.ReactText;
+  children?: RenderType<TextProps> | React.ReactText;
   checked?: boolean;
   onChange?: (checked: boolean) => void;
   status?: EvaStatus;

--- a/src/components/ui/select/select.component.tsx
+++ b/src/components/ui/select/select.component.tsx
@@ -497,7 +497,7 @@ export class Select extends React.Component<SelectProps, State> {
           style={[styles.popover, evaStyle.popover]}
           visible={this.state.listVisible}
           fullWidth={true}
-          anchor={() => this.renderInputElement(touchableProps, evaStyle)}
+          anchor={this.renderInputElement(touchableProps, evaStyle)}
           onBackdropPress={this.onBackdropPress}>
           <List
             style={styles.list}

--- a/src/components/ui/select/select.component.tsx
+++ b/src/components/ui/select/select.component.tsx
@@ -26,7 +26,7 @@ import {
   FalsyFC,
   FalsyText,
   IndexPath,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -59,13 +59,13 @@ export interface SelectProps extends TouchableWebProps, SelectStyledProps {
   children?: ChildrenWithProps<SelectItemProps | SelectGroupProps>;
   selectedIndex?: IndexPath | IndexPath[];
   onSelect?: (index: IndexPath | IndexPath[]) => void;
-  value?: RenderProp<TextProps> | React.ReactText;
+  value?: RenderType<TextProps> | React.ReactText;
   multiSelect?: boolean;
-  placeholder?: RenderProp<TextProps> | React.ReactText;
-  label?: RenderProp<TextProps> | React.ReactText;
-  caption?: RenderProp<TextProps> | React.ReactText;
-  accessoryLeft?: RenderProp<Partial<ImageProps>>;
-  accessoryRight?: RenderProp<Partial<ImageProps>>;
+  placeholder?: RenderType<TextProps> | React.ReactText;
+  label?: RenderType<TextProps> | React.ReactText;
+  caption?: RenderType<TextProps> | React.ReactText;
+  accessoryLeft?: RenderType<Partial<ImageProps>>;
+  accessoryRight?: RenderType<Partial<ImageProps>>;
   status?: EvaStatus;
   size?: EvaInputSize;
 }

--- a/src/components/ui/select/selectItem.component.tsx
+++ b/src/components/ui/select/selectItem.component.tsx
@@ -16,7 +16,7 @@ import {
   FalsyFC,
   FalsyText,
   PropsService,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -44,9 +44,9 @@ type TouchableSelectProps = Overwrite<TouchableWebProps, {
 }>;
 
 export interface SelectItemProps extends TouchableSelectProps, SelectItemStyledProps {
-  title?: RenderProp<TextProps> | React.ReactText;
-  accessoryLeft?: RenderProp<Partial<ImageProps>>;
-  accessoryRight?: RenderProp<Partial<ImageProps>>;
+  title?: RenderType<TextProps> | React.ReactText;
+  accessoryLeft?: RenderType<Partial<ImageProps>>;
+  accessoryRight?: RenderType<Partial<ImageProps>>;
   selected?: boolean;
   descriptor?: SelectItemDescriptor;
 }

--- a/src/components/ui/tab/tab.component.tsx
+++ b/src/components/ui/tab/tab.component.tsx
@@ -14,7 +14,7 @@ import {
 import {
   FalsyFC,
   FalsyText,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -34,8 +34,8 @@ type TabStyledProps = Overwrite<StyledComponentProps, {
 
 export interface TabProps extends TouchableWebProps, TabStyledProps {
   children?: React.ReactElement;
-  title?: RenderProp<TextProps> | React.ReactText;
-  icon?: RenderProp<Partial<ImageProps>>;
+  title?: RenderType<TextProps> | React.ReactText;
+  icon?: RenderType<Partial<ImageProps>>;
   selected?: boolean;
   onSelect?: (selected: boolean) => void;
 }

--- a/src/components/ui/toggle/toggle.component.tsx
+++ b/src/components/ui/toggle/toggle.component.tsx
@@ -22,7 +22,7 @@ import {
 import {
   EvaStatus,
   FalsyText,
-  RenderProp,
+  RenderType,
   RTLService,
   TouchableWeb,
   TouchableWebProps,
@@ -42,7 +42,7 @@ type ToggleStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 export interface ToggleProps extends TouchableWebProps, ToggleStyledProps {
-  children?: RenderProp<TextProps> | React.ReactText;
+  children?: RenderType<TextProps> | React.ReactText;
   checked?: boolean;
   onChange?: (checked: boolean) => void;
   status?: EvaStatus;

--- a/src/components/ui/tooltip/tooltip.component.tsx
+++ b/src/components/ui/tooltip/tooltip.component.tsx
@@ -16,7 +16,7 @@ import {
 import {
   FalsyFC,
   FalsyText,
-  RenderProp,
+  RenderType,
   Overwrite,
 } from '../../devsupport';
 import {
@@ -37,12 +37,12 @@ type TooltipStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 type TooltipPopoverProps = Overwrite<PopoverProps, {
-  children: RenderProp<TextProps> | React.ReactText;
+  children: RenderType<TextProps> | React.ReactText;
 }>;
 
 export interface TooltipProps extends TooltipPopoverProps, TooltipStyledProps {
-  accessoryLeft?: RenderProp<Partial<ImageProps>>;
-  accessoryRight?: RenderProp<Partial<ImageProps>>;
+  accessoryLeft?: RenderType<Partial<ImageProps>>;
+  accessoryRight?: RenderType<Partial<ImageProps>>;
 }
 
 export type TooltipElement = React.ReactElement<TooltipProps>;

--- a/src/components/ui/topNavigation/topNavigation.component.tsx
+++ b/src/components/ui/topNavigation/topNavigation.component.tsx
@@ -13,7 +13,7 @@ import {
 import {
   FalsyFC,
   FalsyText,
-  RenderProp,
+  RenderType,
   Overwrite,
 } from '../../devsupport';
 import {
@@ -28,10 +28,10 @@ type TopNavigationStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 export interface TopNavigationProps extends ViewProps, TopNavigationStyledProps {
-  title?: RenderProp<TextProps> | React.ReactText;
-  subtitle?: RenderProp<TextProps> | React.ReactText;
-  accessoryLeft?: RenderProp;
-  accessoryRight?: RenderProp;
+  title?: RenderType<TextProps> | React.ReactText;
+  subtitle?: RenderType<TextProps> | React.ReactText;
+  accessoryLeft?: RenderType;
+  accessoryRight?: RenderType;
   alignment?: AlignmentProp;
 }
 

--- a/src/components/ui/topNavigation/topNavigationAction.component.tsx
+++ b/src/components/ui/topNavigation/topNavigationAction.component.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import {
   FalsyFC,
-  RenderProp,
+  RenderType,
   TouchableWeb,
   TouchableWebElement,
   TouchableWebProps,
@@ -31,7 +31,7 @@ type TopNavigationActionStyledProps = Overwrite<StyledComponentProps, {
 }>;
 
 export interface TopNavigationActionProps extends TouchableWebProps, TopNavigationActionStyledProps {
-  icon?: RenderProp<Partial<ImageProps>>;
+  icon?: RenderType<Partial<ImageProps>>;
 }
 
 export type TopNavigationActionElement = React.ReactElement<TopNavigationActionProps>;

--- a/src/showcases/components/popover/popoverFullWidth.component.tsx
+++ b/src/showcases/components/popover/popoverFullWidth.component.tsx
@@ -15,7 +15,7 @@ export const PopoverFullWidthShowcase = () => {
   return (
     <Popover
       visible={visible}
-      anchor={renderToggleButton}
+      anchor={renderToggleButton()}
       fullWidth={true}
       onBackdropPress={() => setVisible(false)}>
       <Layout style={styles.content}>

--- a/src/showcases/components/popover/popoverPlacement.component.tsx
+++ b/src/showcases/components/popover/popoverPlacement.component.tsx
@@ -51,7 +51,7 @@ export const PopoverPlacementShowcase = () => {
       <View style={styles.buttonContainer}>
 
         <Popover
-          anchor={renderToggleButton}
+          anchor={renderToggleButton()}
           visible={visible}
           placement={placement}
           onBackdropPress={() => setVisible(false)}>

--- a/src/showcases/components/popover/popoverSimpleUsage.component.tsx
+++ b/src/showcases/components/popover/popoverSimpleUsage.component.tsx
@@ -15,7 +15,7 @@ export const PopoverSimpleUsageShowcase = () => {
   return (
     <Popover
       visible={visible}
-      anchor={renderToggleButton}
+      anchor={renderToggleButton()}
       onBackdropPress={() => setVisible(false)}>
       <Layout style={styles.content}>
         <Avatar

--- a/src/showcases/components/popover/popoverStyledBackdrop.component.tsx
+++ b/src/showcases/components/popover/popoverStyledBackdrop.component.tsx
@@ -16,7 +16,7 @@ export const PopoverStyledBackdropShowcase = () => {
     <Popover
       backdropStyle={styles.backdrop}
       visible={visible}
-      anchor={renderToggleButton}
+      anchor={renderToggleButton()}
       onBackdropPress={() => setVisible(false)}>
       <Layout style={styles.content}>
         <Avatar


### PR DESCRIPTION
Use a sum type that include both the previous RenderProp and a react element.

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

An attempt to fix https://github.com/akveo/react-native-ui-kitten/issues/1146
This PR should not include breaking changes; it will just allow most of the components to accept a react element:

```
<TopNavigation accessoryLeft={<BackAction someProps={123} />} />
```

It is still allowed to pass a render-prop function that is defined in the component itself, (i.e `<TopNavigation accessoryLeft={() => <BackAction someProps={123} />} />`) and a reference to the component (i.e `<TopNavigation accessoryLeft={BackAction>} />`).

I haven't find a way to discriminate between those two values, as they are both just plain function, but should be treated differently. The first one should be rendered as `component(props)`, while the latter should be created with `React.createElement(component, props)`. Currently, `createElement` is used for both cases, meaning that currently a render function like `<TopNavigation accessoryLeft={() => <BackAction someProps={123} />} />` will not behave as you may expect: the component will re-mount every time the parent component re-render, and as such it will lose any local state, lose focus, etc. Which is basically the current behaviour. It's not in the scope of this PR to solve this issue though. 