### PR TITLE
feat(calendar): add visibleDate prop to RangeCalendar

### DIFF
--- a/src/components/ui/calendar/rangeCalendar.component.tsx
+++ b/src/components/ui/calendar/rangeCalendar.component.tsx
@@ -20,6 +20,7 @@ import { CalendarRange } from './type';
 
 export interface RangeCalendarProps<D = Date> extends StyledComponentProps, BaseCalendarProps<D> {
   range?: CalendarRange<D>;
+  visibleDate?: D;
   onSelect?: (range: CalendarRange<D>) => void;
 }
 
@@ -74,6 +75,8 @@ export type RangeCalendarElement<D = Date> = React.ReactElement<RangeCalendarPro
  * to render instead of default year cell.
  * Called with a date for this cell and styles provided by Eva.
  *
+ * @property {D} visibleDate - Sets the visibleDate of the calendar. Defaults to today's date.
+ *
  * @property {ViewProps} ...ViewProps - Any props applied to View component.
  *
  * @overview-example RangeCalendarSimpleUsage
@@ -110,9 +113,15 @@ export class RangeCalendar<D = Date> extends BaseCalendarComponent<RangeCalendar
   }
 
   // BaseCalendarComponent
-
   protected createDates(date: D): DateBatch<D> {
     return this.dataService.createDayPickerData(date, this.props.range);
+  }
+
+  public UNSAFE_componentWillReceiveProps(nextProps: Readonly<BaseCalendarProps<D> & RangeCalendarProps<D>>,
+                                   nextContext: any): void {
+    if (this.props.visibleDate && this.props.visibleDate !== nextProps.visibleDate) {
+      this.setState({visibleDate: this.dateService.getMonthStart(nextProps.visibleDate)});
+    }
   }
 
   protected selectedDate(): D {


### PR DESCRIPTION
Allows view to be adjusted when range is set outside
the currently displayed month/year.

Previously when new date range was set outside of the
displayed month the view wouldn't update, and the user
would need to manually change the view to find the
selected range.

This allows for the display to be set programatically _and_ for the
user to navigate with the UI buttons.

This implementation Uses `UNSAFE_componentWillReceiveProps`
because it was not possible to use `getDerivedStateFromProps` without
breaking the previous/next month buttons. This method allows 
for the display to be set programmatically while still allowing
the user to page forward/back.

First PR. / contribution to an open source project of any kind,
so please forgive any rookie mistakes.

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

allows the view to be updated when the selected range is set programatically 
outside of display on screen.