### PR TITLE
fix(components): change placeholder color when datepicker has a value

### DIFF
--- a/src/components/ui/datepicker/baseDatepicker.component.tsx
+++ b/src/components/ui/datepicker/baseDatepicker.component.tsx
@@ -147,6 +147,7 @@ export abstract class BaseDatepickerComponent<P, D = Date> extends React.Compone
       placeholder: {
         marginHorizontal: textMarginHorizontal,
         color: placeholderColor,
+        fontSize: textFontSize,
       },
       icon: {
         width: iconWidth,
@@ -226,7 +227,7 @@ export abstract class BaseDatepickerComponent<P, D = Date> extends React.Compone
           component={this.props.accessoryLeft}
         />
         <FalsyText
-          style={evaStyle.text}
+          style={this.props.date ? evaStyle.text : evaStyle.placeholder}
           numberOfLines={1}
           ellipsizeMode='tail'
           component={this.getComponentTitle()}


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
Set a different color for placeholder and selected date on datepicker to have the same behavior as the Input. It helps to have a homogeneous form. This issue is related : https://github.com/akveo/react-native-ui-kitten/issues/1224.

I also added this to my `mapping.json` :

```
{
	"components": {
		"Datepicker": {
			"appearances": {
				"default": {
					"variantGroups": {
						"status": {
							"basic": {
								"textColor": "text-basic-color"
							}
						}
					}
				}
			}
		}
	}
}
```