### PR TITLE
fix(moment): Sort weekdays by locale

### DIFF
--- a/src/moment/momentDate.service.ts
+++ b/src/moment/momentDate.service.ts
@@ -162,8 +162,8 @@ export class MomentDateService extends DateService<Moment> {
         [TranslationWidth.LONG]: momentLocaleData.months(),
       },
       days: {
-        [TranslationWidth.SHORT]: momentLocaleData.weekdaysShort(),
-        [TranslationWidth.LONG]: momentLocaleData.weekdays(),
+        [TranslationWidth.SHORT]: momentLocaleData.weekdaysShort(true),
+        [TranslationWidth.LONG]: momentLocaleData.weekdays(true),
       },
     };
   }


### PR DESCRIPTION
#### Short description:

Calendar's header was showing Sunday (Sun) as a first day of the week for all locals, but the dates below were displayed correctly according to the locale passed in. For example, for the en-GB locale, the Calendar showed Sunday January 11th when it was actually Monday January 11th.
According to moment.js documentation a boolean parameter can be passed to weekdaysShort() and weekdays() methods since version 2.24.0. This allows the days of the week to be returned in locale-specific order, which fixes the issue.

I haven't added any tests as there are no tests covering different locales scenarios. Please advice on this if they are needed.
