### PR TITLE
fix: disabled prop didn't make action grey

### DIFF
--- a/src/components/ui/topNavigation/topNavigationAction.component.tsx
+++ b/src/components/ui/topNavigation/topNavigationAction.component.tsx
@@ -88,6 +88,10 @@ export class TopNavigationAction extends React.Component<TopNavigationActionProp
     this.props.onPressOut && this.props.onPressOut(event);
   };
 
+  componentDidMount() {
+    this.props.disabled && this.props.eva.dispatch([Interaction.HOVER]);
+  }
+
   private getComponentStyle = (source: StyleType) => {
     const {
       iconTintColor,


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Im not sure why `eva.styles` not reacting on disabled prop in `topNavigation action`. Maybe we need to update eva logic from inside mapping. Let me know what you think

Closes #1277 