### PR TITLE
fix: add change orientation event with modal render

### DIFF
--- a/src/components/ui/modal/modal.component.tsx
+++ b/src/components/ui/modal/modal.component.tsx
@@ -94,13 +94,6 @@ export class Modal extends React.PureComponent<ModalProps, State> {
     this.modalId = ModalService.hide(this.modalId);
   };
 
-  public forceRender = (): void => {
-    if(this.props.visible) {
-      this.hide();
-      this.show();
-    }
-  }
-
   public componentDidMount(): void {
     Dimensions.addEventListener('change', this.forceRender);
     if (!this.modalId && this.props.visible) {
@@ -128,6 +121,12 @@ export class Modal extends React.PureComponent<ModalProps, State> {
   public componentWillUnmount(): void {
     Dimensions.removeEventListener('change', this.forceRender);
     this.hide();
+  }
+
+  private forceRender = (): void => {
+    if(this.props.visible) {
+      ModalService.update(this.modalId, this.renderMeasuringContentElement());
+    }
   }
 
   private onContentMeasure = (contentFrame: Frame): void => {

--- a/src/components/ui/modal/modal.component.tsx
+++ b/src/components/ui/modal/modal.component.tsx
@@ -11,6 +11,7 @@ import {
   View,
   ViewProps,
   ViewStyle,
+  Dimensions,
 } from 'react-native';
 import {
   Frame,
@@ -93,7 +94,15 @@ export class Modal extends React.PureComponent<ModalProps, State> {
     this.modalId = ModalService.hide(this.modalId);
   };
 
+  public forceRender = (): void => {
+    if(this.props.visible) {
+      this.hide();
+      this.show();
+    }
+  }
+
   public componentDidMount(): void {
+    Dimensions.addEventListener('change', this.forceRender);
     if (!this.modalId && this.props.visible) {
       this.show();
       return;
@@ -117,6 +126,7 @@ export class Modal extends React.PureComponent<ModalProps, State> {
   }
 
   public componentWillUnmount(): void {
+    Dimensions.removeEventListener('change', this.forceRender);
     this.hide();
   }
 

--- a/src/components/ui/modal/modal.component.tsx
+++ b/src/components/ui/modal/modal.component.tsx
@@ -95,7 +95,7 @@ export class Modal extends React.PureComponent<ModalProps, State> {
   };
 
   public componentDidMount(): void {
-    Dimensions.addEventListener('change', this.forceRender);
+    Dimensions.addEventListener('change', this.onDimensionChange);
     if (!this.modalId && this.props.visible) {
       this.show();
       return;
@@ -119,11 +119,11 @@ export class Modal extends React.PureComponent<ModalProps, State> {
   }
 
   public componentWillUnmount(): void {
-    Dimensions.removeEventListener('change', this.forceRender);
+    Dimensions.removeEventListener('change', this.onDimensionChange);
     this.hide();
   }
 
-  private forceRender = (): void => {
+  private onDimensionChange = (): void => {
     if(this.props.visible) {
       ModalService.update(this.modalId, this.renderMeasuringContentElement());
     }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
The solutions is quite simple - I just render new modal with new id. I dont think there would be a possibility to apply new position to old one. If you think we can apply new position for the modal - let me know pls

Closes #1132