### PR TITLE
feat(date-fns): bump date-fns to v2

### DIFF
--- a/src/components/ui/calendar/baseCalendar.component.tsx
+++ b/src/components/ui/calendar/baseCalendar.component.tsx
@@ -32,8 +32,9 @@ import {
   CalendarDateInfo,
   CalendarViewMode,
   CalendarViewModes,
-  CalendarViewModeId
+  CalendarViewModeId,
 } from './type';
+import { TranslationWidth } from './i18n/type';
 import { DateService } from './service/date.service';
 import { NativeDateService } from './service/nativeDate.service';
 import {
@@ -67,13 +68,6 @@ interface State<D> {
 const PICKER_ROWS: number = 4;
 const PICKER_COLUMNS: number = 3;
 const VIEWS_IN_PICKER: number = PICKER_ROWS * PICKER_COLUMNS;
-
-const FORMAT_DAY: string = 'D';
-const FORMAT_MONTH: string = 'MMM';
-const FORMAT_YEAR: string = 'YYYY';
-const FORMAT_HEADER_DATE: string = 'MMMM YYYY';
-const FORMAT_HEADER_MONTH: string = 'YYYY';
-const FORMAT_HEADER_YEAR: string = 'YYYY';
 
 export abstract class BaseCalendarComponent<P, D = Date> extends React.Component<BaseCalendarProps<D> & P, State<D>> {
 
@@ -298,14 +292,16 @@ export abstract class BaseCalendarComponent<P, D = Date> extends React.Component
   private createViewModeHeaderTitle = (date: D, viewMode: CalendarViewMode): string => {
     switch (viewMode.id) {
       case CalendarViewModes.DATE.id: {
-        return this.dateService.format(date, FORMAT_HEADER_DATE);
+        const month: string = this.props.dateService.getMonthName(date, TranslationWidth.LONG);
+        const year: number = this.props.dateService.getYear(date);
+        return `${month} ${year}`;
       }
       case CalendarViewModes.MONTH.id: {
-        return this.dateService.format(date, FORMAT_HEADER_MONTH);
+        return `${this.dateService.getYear(date)}`;
       }
       case CalendarViewModes.YEAR.id: {
-        const minDateFormat: string = this.dateService.format(this.min, FORMAT_HEADER_YEAR);
-        const maxDateFormat: string = this.dateService.format(this.max, FORMAT_HEADER_YEAR);
+        const minDateFormat: number = this.dateService.getYear(this.min);
+        const maxDateFormat: number = this.dateService.getYear(this.max);
 
         return `${minDateFormat} - ${maxDateFormat}`;
       }
@@ -338,7 +334,7 @@ export abstract class BaseCalendarComponent<P, D = Date> extends React.Component
       <CalendarDateContent
         style={evaStyle.container}
         textStyle={evaStyle.text}>
-        {this.dateService.format(date, FORMAT_DAY)}
+        {this.dateService.getDate(date)}
       </CalendarDateContent>
     );
   };
@@ -348,7 +344,7 @@ export abstract class BaseCalendarComponent<P, D = Date> extends React.Component
       <CalendarDateContent
         style={evaStyle.container}
         textStyle={evaStyle.text}>
-        {this.dateService.format(date, FORMAT_MONTH)}
+        {this.dateService.getMonthName(date, TranslationWidth.SHORT)}
       </CalendarDateContent>
     );
   };
@@ -358,7 +354,7 @@ export abstract class BaseCalendarComponent<P, D = Date> extends React.Component
       <CalendarDateContent
         style={evaStyle.container}
         textStyle={evaStyle.text}>
-        {this.dateService.format(date, FORMAT_YEAR)}
+        {this.dateService.getYear(date)}
       </CalendarDateContent>
     );
   };

--- a/src/components/ui/calendar/components/calendarDateContent.component.tsx
+++ b/src/components/ui/calendar/components/calendarDateContent.component.tsx
@@ -16,7 +16,7 @@ import { Text } from '../../text/text.component';
 
 export interface CalendarDateContentProps extends ViewProps {
   textStyle?: StyleProp<TextStyle>;
-  children: string;
+  children: React.ReactText;
 }
 
 export type CalendarDateContentElement = React.ReactElement<CalendarDateContentProps>;

--- a/src/date-fns/dateFnsDate.service.spec.ts
+++ b/src/date-fns/dateFnsDate.service.spec.ts
@@ -17,16 +17,16 @@ describe('@date-fns: service checks', () => {
 
   it('* should parse date according to the MM.dd.yyyy format', () => {
     const date = '06.15.2018';
-    expect(dateService.parse(date, '')).toEqual(new Date(2018, 5, 15));
+    expect(dateService.parse(date, 'MM.dd.yyyy')).toEqual(new Date(2018, 5, 15));
   });
 
   it('* should not format if date isn\'t passed', () => {
-    expect(() => dateService.format(undefined, 'DD.MM.YYYY')).not.toThrow();
-    expect(dateService.format(undefined, 'DD.MM.YYYY')).toEqual('');
+    expect(() => dateService.format(undefined, 'dd.MM.YYYY')).not.toThrow();
+    expect(dateService.format(undefined, 'dd.MM.YYYY')).toEqual('');
   });
 
   describe('service global config', () => {
-    const FORMAT: string = 'MM-DD-YYYY';
+    const FORMAT: string = 'MM-dd-yyyy';
     const year: number = 2010;
     const monthIndex: number = 10;
     const month: number = monthIndex + 1;
@@ -35,14 +35,9 @@ describe('@date-fns: service checks', () => {
     const formattedDate: string = `${month}-${day}-${year}`;
 
     beforeEach(() => {
-      dateService = new DateFnsService(
-        'en',
-        {
-          format: FORMAT,
-          parseOptions: {},
-          formatOptions: {},
-        },
-      );
+      dateService = new DateFnsService('en', {
+        format: FORMAT,
+      });
     });
 
     it('* should use format from global config if isn\'t passed as parameter', () => {
@@ -65,7 +60,7 @@ describe('@date-fns: service checks', () => {
     });
 
     it('* should pass formatOptions to format function', () => {
-      expect(dateService.format(date, 'DD/MM/YYYY')).toEqual('20/11/2010');
+      expect(dateService.format(date, 'dd/MM/yyyy')).toEqual('20/11/2010');
     });
   });
 });

--- a/src/date-fns/dateFnsDate.service.ts
+++ b/src/date-fns/dateFnsDate.service.ts
@@ -5,49 +5,45 @@
  */
 
 import {
-  I18nConfig,
   NativeDateService,
   NativeDateServiceOptions,
 } from '@ui-kitten/components';
-// @ts-ignore
-import dateFnsParse, { default as rollupParse } from 'date-fns/parse';
-// @ts-ignore
-import dateFnsFormat, { default as rollupFormat } from 'date-fns/format';
-
-const parse = rollupParse || dateFnsParse;
-const formatDate = rollupFormat || dateFnsFormat;
+import dateFnsParse from 'date-fns/parse';
+import dateFnsFormat from 'date-fns/format';
 
 export interface DateFnsOptions extends NativeDateServiceOptions {
-  parseOptions: {};
-  formatOptions: {};
+  parseOptions?: {};
+  formatOptions?: {};
 }
+
+const DEFAULT_OPTIONS: DateFnsOptions = {
+  format: 'dd/MM/yyyy',
+  parseOptions: {
+    useAdditionalDayOfYearTokens: true,
+    useAdditionalWeekYearTokens: true,
+  },
+  formatOptions: {
+    useAdditionalDayOfYearTokens: true,
+    useAdditionalWeekYearTokens: true,
+  },
+};
 
 export class DateFnsService extends NativeDateService {
 
-  protected options: Partial<DateFnsOptions> = {
-    format: `DD/MM/YYYY`,
-  };
-
   constructor(locale: string = 'en', options?: DateFnsOptions) {
-    super(locale, options);
-    this.options = options || this.options;
+    super(locale, { ...DEFAULT_OPTIONS, ...options });
   }
 
   public format(date: Date, format: string): string {
     if (date) {
-      return formatDate(date, format || this.options.format, this.options.formatOptions);
+      return dateFnsFormat(date, format || this.options.format, (this.options as DateFnsOptions).formatOptions);
     }
 
     return '';
   }
 
   public parse(date: string, format: string): Date {
-    // Parse format is not supported in current version of date-fns
-    return this.parseDate(date);
-  }
-
-  private parseDate(date: string): Date {
-    return parse(date);
+    return dateFnsParse(date, format || this.options.format, new Date(), (this.options as DateFnsOptions).parseOptions);
   }
 
   public getId(): string {

--- a/src/date-fns/package.json
+++ b/src/date-fns/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "date-fns": "^1.30.1"
+    "date-fns": "2"
   },
   "peerDependencies": {
     "@ui-kitten/components": "5.0.0",

--- a/src/moment/momentDate.service.ts
+++ b/src/moment/momentDate.service.ts
@@ -8,13 +8,7 @@ import {
   DateService,
   TranslationWidth,
 } from '@ui-kitten/components';
-// @ts-ignore
-import _moment, {
-  default as _rollupMoment,
-  Moment,
-} from 'moment';
-
-const moment = _rollupMoment || _moment;
+import moment, { Moment } from 'moment';
 
 export class MomentDateService extends DateService<Moment> {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5360,10 +5360,10 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+date-fns@2:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
+  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
 
 dateformat@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
 
Update @ui-kitten/date-fns package to use date-fns v2.
- Adds ability to parse dates with specified format
- Uses [Unicode Tokens](https://date-fns.org/v2.17.0/docs/Unicode-Tokens)
- [Full Changelog](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20)