### PR TITLE
Fix UX issue with Checkbox Indeterminate showcase

### DIFF
--- a/src/showcases/components/checkbox/checkboxIndeterminate.component.tsx
+++ b/src/showcases/components/checkbox/checkboxIndeterminate.component.tsx
@@ -13,6 +13,7 @@ export const CheckboxIndeterminateShowcase = () => {
     setReadChecked(checked);
     setWriteChecked(checked);
     setAllChecked(checked);
+    updateGroup(checked, checked);
   };
 
   const onReadCheckedChange = (checked) => {


### PR DESCRIPTION

 #### Short description of what this resolves:
On clicking the parent checkbox, it should become checked if all children checkboxes are checked. Currently, it stays indeterminate.