### PR TITLE
fix(autocomplete): fixed the double-click required to select an item …

### DIFF
--- a/src/components/ui/autocomplete/autocomplete.component.tsx
+++ b/src/components/ui/autocomplete/autocomplete.component.tsx
@@ -218,6 +218,7 @@ export class Autocomplete extends React.Component<AutocompleteProps, State> {
         onBackdropPress={this.onBackdropPress}>
         <List
           style={styles.list}
+          keyboardShouldPersistTaps='always'
           data={this.data}
           bounces={false}
           renderItem={this.renderItem}


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

There is a bug in the auto-suggest which requires the user to click out of the keyboard before selecting an item on the list. This line solves this issue by utilising the **keyboardShouldPersistTaps** prop from ScrollView (and by extension FlatList, which is what in under the hood of autocomplete). I leave this hardcoded as I don't suggest you would want the current behaviour in any scenario.

Please see below, current behaviour vs fix:


https://user-images.githubusercontent.com/10847190/117220214-b1219a80-adfe-11eb-8fd1-eab7f011d8ff.mov


https://user-images.githubusercontent.com/10847190/117220221-b252c780-adfe-11eb-803f-137bd2b2c4da.mov


