### PR TITLE
Android-specific popover positioning fix

### DIFF
--- a/src/components/ui/popover/type.ts
+++ b/src/components/ui/popover/type.ts
@@ -8,6 +8,8 @@ import {
   FlexStyle,
   StyleProp,
   StyleSheet,
+  Platform,
+  StatusBar
 } from 'react-native';
 import {
   Frame,
@@ -158,6 +160,8 @@ export interface PopoverPlacement {
   fits(frame: Frame, other: Frame): boolean;
 }
 
+const androidSpecificOffset = Platform.OS === 'android' ? StatusBar.currentHeight : 0;
+
 export class PopoverPlacements {
 
   static RIGHT_START: PopoverPlacement = new class implements PopoverPlacement {
@@ -168,7 +172,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x,
-        origin.y - (options.other.size.height - size.height) / 2 + options.offsets.origin.y,
+        origin.y - (options.other.size.height - size.height) / 2 + options.offsets.origin.y + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -205,7 +209,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x,
-        origin.y - (options.other.size.height - size.height) / 2 + options.offsets.origin.y,
+        origin.y - (options.other.size.height - size.height) / 2 + options.offsets.origin.y + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -242,7 +246,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x,
-        origin.y + (options.other.size.height - size.height) / 2 - options.offsets.size.height,
+        origin.y + (options.other.size.height - size.height) / 2 - options.offsets.size.height + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -279,7 +283,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x,
-        origin.y + (options.other.size.height - size.height) / 2 - options.offsets.size.height,
+        origin.y + (options.other.size.height - size.height) / 2 - options.offsets.size.height + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -321,7 +325,7 @@ export class PopoverPlacements {
 
       return new Frame(
         x,
-        origin.y,
+        origin.y + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -367,7 +371,7 @@ export class PopoverPlacements {
 
       return new Frame(
         x,
-        origin.y,
+        origin.y + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -408,7 +412,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x - (options.other.size.width - size.width) / 2 + options.offsets.origin.x,
-        origin.y,
+        origin.y + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -445,7 +449,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x - (options.other.size.width - size.width) / 2 + options.offsets.origin.x,
-        origin.y,
+        origin.y + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -482,7 +486,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x + (options.other.size.width - size.width) / 2 - options.offsets.size.width,
-        origin.y,
+        origin.y + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -519,7 +523,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x + (options.other.size.width - size.width) / 2 - options.offsets.size.width,
-        origin.y,
+        origin.y + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -561,7 +565,7 @@ export class PopoverPlacements {
 
       return new Frame(
         x,
-        origin.y - options.offsets.size.height,
+        origin.y - options.offsets.size.height + androidSpecificOffset,
         size.width,
         size.height,
       );
@@ -608,7 +612,7 @@ export class PopoverPlacements {
 
       return new Frame(
         x,
-        origin.y + options.offsets.origin.y,
+        origin.y + options.offsets.origin.y + androidSpecificOffset,
         size.width,
         size.height,
       );

--- a/src/components/ui/popover/type.ts
+++ b/src/components/ui/popover/type.ts
@@ -172,7 +172,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x,
-        origin.y - (options.other.size.height - size.height) / 2 + options.offsets.origin.y + androidSpecificOffset,
+        origin.y - (options.other.size.height - size.height) / 2 + options.offsets.origin.y,
         size.width,
         size.height,
       );
@@ -209,7 +209,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x,
-        origin.y - (options.other.size.height - size.height) / 2 + options.offsets.origin.y + androidSpecificOffset,
+        origin.y - (options.other.size.height - size.height) / 2 + options.offsets.origin.y,
         size.width,
         size.height,
       );
@@ -246,7 +246,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x,
-        origin.y + (options.other.size.height - size.height) / 2 - options.offsets.size.height + androidSpecificOffset,
+        origin.y + (options.other.size.height - size.height) / 2 - options.offsets.size.height,
         size.width,
         size.height,
       );
@@ -283,7 +283,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x,
-        origin.y + (options.other.size.height - size.height) / 2 - options.offsets.size.height + androidSpecificOffset,
+        origin.y + (options.other.size.height - size.height) / 2 - options.offsets.size.height,
         size.width,
         size.height,
       );
@@ -412,7 +412,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x - (options.other.size.width - size.width) / 2 + options.offsets.origin.x,
-        origin.y + androidSpecificOffset,
+        origin.y,
         size.width,
         size.height,
       );
@@ -449,7 +449,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x - (options.other.size.width - size.width) / 2 + options.offsets.origin.x,
-        origin.y + androidSpecificOffset,
+        origin.y,
         size.width,
         size.height,
       );
@@ -486,7 +486,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x + (options.other.size.width - size.width) / 2 - options.offsets.size.width,
-        origin.y + androidSpecificOffset,
+        origin.y,
         size.width,
         size.height,
       );
@@ -523,7 +523,7 @@ export class PopoverPlacements {
 
       return new Frame(
         origin.x + (options.other.size.width - size.width) / 2 - options.offsets.size.width,
-        origin.y + androidSpecificOffset,
+        origin.y,
         size.width,
         size.height,
       );


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [X] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Minor bugfix - repositions the popover frame on Android to include the status bar offset (so that it won't collide with e.g. inputs and buttons, as I've noticed it does on Expo Go).