### PR TITLE
feat(metro): add support for disabling custom mapping file watcher

### DIFF
--- a/src/metro-config/index.ts
+++ b/src/metro-config/index.ts
@@ -25,8 +25,6 @@ const customMappingWatchOptions = {
  * @param metroConfig - configuration of Metro Bundler used in project.
  * @link https://facebook.github.io/metro/docs/configuration
  *
- * @param enableWatcher - if the custom mapping file should be watched for changes (disable in CI/CD environments)
- *
  * @returns a combination of two metro configurations.
  *
  * @example Usage
@@ -44,7 +42,7 @@ const customMappingWatchOptions = {
  * });
  * ```
  */
-export const create = (evaConfig: EvaConfig, metroConfig?: MetroConfigType, enableWatcher: boolean = true): MetroConfigType => {
+export const create = (evaConfig: EvaConfig, metroConfig?: MetroConfigType): MetroConfigType => {
 
   const handleMetroEvent = (event): void => {
     const reporter = metroConfig && metroConfig.reporter || defaultMetroConfig.reporter;
@@ -59,7 +57,7 @@ export const create = (evaConfig: EvaConfig, metroConfig?: MetroConfigType, enab
       const customMappingPath: string = ProjectService.resolvePath(evaConfig.customMappingPath);
       const customMappingExists: boolean = Fs.existsSync(customMappingPath);
 
-      if (customMappingExists && enableWatcher) {
+      if (customMappingExists && (evaConfig.watch || evaConfig.watch === undefined)) {
         Fs.watchFile(customMappingPath, customMappingWatchOptions, () => {
           BootstrapService.run(evaConfig);
         });

--- a/src/metro-config/index.ts
+++ b/src/metro-config/index.ts
@@ -25,6 +25,8 @@ const customMappingWatchOptions = {
  * @param metroConfig - configuration of Metro Bundler used in project.
  * @link https://facebook.github.io/metro/docs/configuration
  *
+ * @param enableWatcher - if the custom mapping file should be watched for changes (disable in CI/CD environments)
+ *
  * @returns a combination of two metro configurations.
  *
  * @example Usage
@@ -42,7 +44,7 @@ const customMappingWatchOptions = {
  * });
  * ```
  */
-export const create = (evaConfig: EvaConfig, metroConfig?: MetroConfigType): MetroConfigType => {
+export const create = (evaConfig: EvaConfig, metroConfig?: MetroConfigType, enableWatcher: boolean = true): MetroConfigType => {
 
   const handleMetroEvent = (event): void => {
     const reporter = metroConfig && metroConfig.reporter || defaultMetroConfig.reporter;
@@ -57,7 +59,7 @@ export const create = (evaConfig: EvaConfig, metroConfig?: MetroConfigType): Met
       const customMappingPath: string = ProjectService.resolvePath(evaConfig.customMappingPath);
       const customMappingExists: boolean = Fs.existsSync(customMappingPath);
 
-      if (customMappingExists) {
+      if (customMappingExists && enableWatcher) {
         Fs.watchFile(customMappingPath, customMappingWatchOptions, () => {
           BootstrapService.run(evaConfig);
         });

--- a/src/metro-config/services/eva-config.service.ts
+++ b/src/metro-config/services/eva-config.service.ts
@@ -6,6 +6,7 @@ import ProjectService from './project.service';
  *
  * @param {EvaMappingPackageName} evaPackage - the name of the eva package.
  * @param {string} customMappingPath - relative path to custom mapping.
+ * @param {boolean} watch - watch custom mapping file for changes (defaults to true)
  *
  * @example Config for @eva-design/eva package with custom mapping
  * ```
@@ -18,6 +19,7 @@ import ProjectService from './project.service';
 export interface EvaConfig {
   evaPackage: EvaMappingPackageName;
   customMappingPath?: string;
+  watch?: boolean;
 }
 
 export type EvaMappingPackageName = '@eva-design/eva' | '@eva-design/material';


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
Metro bundler runs indefinitely in CI/CD environments when using ui-kitten's metro config because a file watcher is opened. This change provides a way to disable the file watcher in production builds as the mapping is not likely to change. This fixes #1410 