### PR TITLE
fix: prevent styled component from redundant re-renders

### DIFF
--- a/src/components/theme/style/style.spec.tsx
+++ b/src/components/theme/style/style.spec.tsx
@@ -171,9 +171,9 @@ describe('@style: ui component checks', () => {
   };
 
   it('styled component should not re-renderer because of parent render', async () => {
-    const rerenderButtonText = 'Rerender';
+    const rerenderButtonText = 'Rerender parent';
     const getRenderCountText = (elementType: string, count: number) => {
-      return `${elementType}: render for ${count} times`;
+      return `${elementType}: render for ${count} ${count === 1 ? 'time' : 'times'}`;
     };
 
     @styled('Test')

--- a/src/components/theme/style/style.spec.tsx
+++ b/src/components/theme/style/style.spec.tsx
@@ -4,11 +4,12 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import {
   TouchableOpacity,
   View,
   ViewProps,
+  Text,
 } from 'react-native';
 import {
   fireEvent,
@@ -160,6 +161,51 @@ describe('@style: ui component checks', () => {
       );
     }
   }
+
+  const Provider = ({ children }) => {
+    return (
+      <StyleProvider styles={computedMapping} theme={theme}>
+        {children}
+      </StyleProvider>
+    );
+  };
+
+  it('styled component should not re-renderer because of parent render', async () => {
+    const rerenderButtonText = 'Rerender';
+    const getRenderCountText = (elementType: string, count: number) => {
+      return `${elementType}: render for ${count} times`;
+    };
+
+    @styled('Test')
+    class ChildStyledComponent extends React.Component<any, any> {
+      renderCount = 0;
+
+      public render(): React.ReactElement<ViewProps> {
+        this.renderCount++;
+        return (
+          <Text>{getRenderCountText('Child', this.renderCount)}</Text>
+        );
+      }
+    }
+
+    const ParentComponent = () => {
+      const [renderCount, setRenderCount] = useState(1);
+      return <View>
+        <TouchableOpacity onPress={() => setRenderCount(renderCount + 1)}>
+          <Text>{rerenderButtonText}</Text>
+        </TouchableOpacity>
+        <Text>{getRenderCountText('Parent', renderCount)}</Text>
+        <ChildStyledComponent />
+      </View>;
+    };
+
+    const renderedComponent: RenderAPI = render(<ParentComponent />, { wrapper: Provider});
+    fireEvent.press(renderedComponent.getByText(rerenderButtonText));
+    fireEvent.press(renderedComponent.getByText(rerenderButtonText));
+
+    expect(renderedComponent.queryByText(getRenderCountText('Parent', 3))).toBeTruthy();
+    expect(renderedComponent.queryByText(getRenderCountText('Child', 1))).toBeTruthy();
+  });
 
   it('static methods are copied over', async () => {
     expect(Test.someStaticValueToCopy).not.toBeFalsy();

--- a/src/components/theme/style/styled.tsx
+++ b/src/components/theme/style/styled.tsx
@@ -101,8 +101,7 @@ const styleInjector = (Component: WrappedComponent, name: string): StyledCompone
     return null;
   }
 
-  class Wrapper extends React.Component<PrivateRefProps, State> {
-
+  class Wrapper extends React.PureComponent<PrivateRefProps, State> {
     public state: State = {
       interaction: [],
     };

--- a/src/components/theme/theme/withStyles.tsx
+++ b/src/components/theme/theme/withStyles.tsx
@@ -56,7 +56,7 @@ export const withStyles = <P extends object, S>(Component: React.ComponentType<P
   type WrappingElement = React.ReactElement<WrappingProps>;
   type WrappedElementInstance = React.ReactInstance;
 
-  class Wrapper extends React.Component<WrappingProps> {
+  class Wrapper extends React.PureComponent<WrappingProps> {
 
     private withThemedProps = (props: P, theme: ThemeType): WrappedProps => {
       const style = createStyles && createStyles(theme);


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Currently most of the components re-render because of parent render. Using `PureComponent` on `styled` HOC resolve the issue.

The components will be re-rendered only after props, theme or inner state changes

Closes #1400