### PR TITLE
[DOC] configure-navigation guide: deprecated prop

### DIFF
--- a/docs/src/articles/guides/configure-navigation.md
+++ b/docs/src/articles/guides/configure-navigation.md
@@ -109,7 +109,7 @@ import { DetailsScreen } from './details.component';
 const { Navigator, Screen } = createStackNavigator();
 
 const HomeNavigator = () => (
-  <Navigator headerMode='none'>
+  <Navigator screenOptions={{headerShown: false}}>
     <Screen name='Home' component={HomeScreen}/>
     <Screen name='Details' component={DetailsScreen}/>
   </Navigator>


### PR DESCRIPTION
Quoting the docs "Stack Navigator: These changes affect users of @react-navigation/stack package.
* headerMode="none" is removed in favor of headerShown: false
"

Link to docs:
https://reactnavigation.org/docs/upgrading-from-5.x/#deprecations

### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves: