### PR TITLE
add needed step to fix issue with Expo for Web

### DIFF
--- a/docs/src/articles/guides/getting-started.md
+++ b/docs/src/articles/guides/getting-started.md
@@ -56,6 +56,12 @@ npm i @ui-kitten/components @eva-design/eva react-native-svg
   <div class="note-body">If you use Expo, you should use `expo install react-native-svg@9.13.6` to install svg package.</div>
 </div>
 
+<div class="note note-warning">
+  <div class="note-body">
+    If you use Expo for Web, you need to add the following underneath the `"web"` key in `app.json` `"build": { "babel": { "include": [ "@ui-kitten/components" ] }`
+  </div>
+</div>
+
 Within non-expo environment, we also need to complete installation for iOS by linking react-native-svg.
 
 ```bash


### PR DESCRIPTION
#### Contribution Guidelines
 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
In order to solve the bug that you bump into as soon as you add `ui-kitten` library to an expo project and try to see the the project in Expo for Web https://github.com/akveo/react-native-ui-kitten/issues/996, this super clean solution needs to be part of the docs, thus this PR. https://github.com/akveo/react-native-ui-kitten/issues/996#issuecomment-790975093