### PR TITLE
fix (calendar): re-render header on arrow press

### DIFF
--- a/src/components/ui/calendar/components/calendarHeader.component.tsx
+++ b/src/components/ui/calendar/components/calendarHeader.component.tsx
@@ -120,7 +120,7 @@ export class CalendarHeader extends React.Component<CalendarHeaderProps> {
           appearance='ghost'
           accessoryRight={this.renderTitleIcon}
           onPress={onTitlePress}>
-          {this.renderTitleElement}
+          {(props) => this.renderTitleElement(props)}
         </Button>
         {lateralNavigationAllowed && this.renderLateralNavigationControls()}
       </View>


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

turn back re-render of calendar header (was broken by #1489)