### PR TITLE
fix (rangePicker): allow to pick one day as completed range

### DIFF
--- a/src/components/ui/calendar/components/picker/calendarPicker.component.tsx
+++ b/src/components/ui/calendar/components/picker/calendarPicker.component.tsx
@@ -53,9 +53,14 @@ export class CalendarPicker<D> extends React.Component<CalendarPickerProps<D>> {
     return range.indexOf(item) === range.length - 1;
   };
 
+  private isOneDayRange = (item: CalendarDateInfo<D>): boolean => {
+    return !!item.oneDayRange;
+  };
+
   private renderCellElement = (item: CalendarDateInfo<D>, index: number): CalendarPickerCellElement<D> => {
     const isFirstRangeItem: boolean = this.isFirstRangeItem(item, this.rangedArray);
     const isLastRangeItem: boolean = this.isLastRangeItem(item, this.rangedArray);
+    const isOneDayRange: boolean = this.isOneDayRange(item);
 
     return (
       <CalendarPickerCell
@@ -68,6 +73,7 @@ export class CalendarPicker<D> extends React.Component<CalendarPickerProps<D>> {
         range={item.range}
         firstRangeItem={isFirstRangeItem}
         lastRangeItem={isLastRangeItem}
+        oneDayRange={isOneDayRange}
         onSelect={this.props.onSelect}
         shouldComponentUpdate={this.props.shouldItemUpdate}>
         {this.props.children}

--- a/src/components/ui/calendar/components/picker/calendarPicker.component.tsx
+++ b/src/components/ui/calendar/components/picker/calendarPicker.component.tsx
@@ -20,7 +20,10 @@ import {
   CalendarPickerCellElement,
   CalendarPickerCellProps,
 } from './calendarPickerCell.component';
-import { CalendarDateInfo } from '../../type';
+import {
+  CalendarDateInfo,
+  RangeRole,
+} from '../../type';
 
 export interface CalendarPickerProps<D> extends ViewProps {
   data: CalendarDateInfo<D>[][];
@@ -37,30 +40,9 @@ export type CalendarPickerElement<D> = React.ReactElement<CalendarPickerProps<D>
 
 export class CalendarPicker<D> extends React.Component<CalendarPickerProps<D>> {
 
-  private get rangedArray(): CalendarDateInfo<D>[] {
-    const { data } = this.props;
-
-    return [].concat(...data).filter((item: CalendarDateInfo<D>) => {
-      return item.range;
-    });
-  }
-
-  private isFirstRangeItem = (item: CalendarDateInfo<D>, range: CalendarDateInfo<D>[]): boolean => {
-    return range.indexOf(item) === 0;
-  };
-
-  private isLastRangeItem = (item: CalendarDateInfo<D>, range: CalendarDateInfo<D>[]): boolean => {
-    return range.indexOf(item) === range.length - 1;
-  };
-
-  private isOneDayRange = (item: CalendarDateInfo<D>): boolean => {
-    return !!item.oneDayRange;
-  };
-
   private renderCellElement = (item: CalendarDateInfo<D>, index: number): CalendarPickerCellElement<D> => {
-    const isFirstRangeItem: boolean = this.isFirstRangeItem(item, this.rangedArray);
-    const isLastRangeItem: boolean = this.isLastRangeItem(item, this.rangedArray);
-    const isOneDayRange: boolean = this.isOneDayRange(item);
+    const firstRangeItem = !!(item.range & RangeRole.start);
+    const lastRangeItem = !!(item.range & RangeRole.end);
 
     return (
       <CalendarPickerCell
@@ -70,10 +52,9 @@ export class CalendarPicker<D> extends React.Component<CalendarPickerProps<D>> {
         disabled={this.props.isItemDisabled(item)}
         bounding={item.bounding}
         today={this.props.isItemToday(item)}
-        range={item.range}
-        firstRangeItem={isFirstRangeItem}
-        lastRangeItem={isLastRangeItem}
-        oneDayRange={isOneDayRange}
+        range={!!item.range}
+        firstRangeItem={firstRangeItem}
+        lastRangeItem={lastRangeItem}
         onSelect={this.props.onSelect}
         shouldComponentUpdate={this.props.shouldItemUpdate}>
         {this.props.children}

--- a/src/components/ui/calendar/components/picker/calendarPickerCell.component.tsx
+++ b/src/components/ui/calendar/components/picker/calendarPickerCell.component.tsx
@@ -27,7 +27,6 @@ export interface CalendarPickerCellProps<D> extends StyledComponentProps, Toucha
   range?: boolean;
   firstRangeItem?: boolean;
   lastRangeItem?: boolean;
-  oneDayRange?: boolean;
   onSelect?: (date: CalendarDateInfo<D>) => void;
   children: ChildrenProp<D>;
   shouldComponentUpdate?: (props: CalendarPickerCellProps<D>, nextProps: CalendarPickerCellProps<D>) => boolean;
@@ -50,31 +49,26 @@ export class CalendarPickerCell<D> extends React.Component<CalendarPickerCellPro
   };
 
   private getContainerBorderRadius = (borderRadius: number): StyleType => {
-    const { firstRangeItem, lastRangeItem, oneDayRange } = this.props;
+    const { firstRangeItem, lastRangeItem } = this.props;
 
-    if (oneDayRange) {
-      return {
-        borderRadius,
-      };
-    }
+    const borderStyle = {
+      borderBottomRightRadius: 0,
+      borderTopRightRadius: 0,
+      borderBottomLeftRadius: 0,
+      borderTopLeftRadius: 0,
+    };
+
     if (firstRangeItem) {
-      return {
-        borderBottomLeftRadius: borderRadius,
-        borderBottomRightRadius: 0,
-        borderTopLeftRadius: borderRadius,
-        borderTopRightRadius: 0,
-      };
-    }
-    if (lastRangeItem) {
-      return {
-        borderBottomLeftRadius: 0,
-        borderBottomRightRadius: borderRadius,
-        borderTopLeftRadius: 0,
-        borderTopRightRadius: borderRadius,
-      };
+      borderStyle.borderBottomLeftRadius = borderRadius;
+      borderStyle.borderTopLeftRadius = borderRadius;
     }
 
-    return {};
+    if (lastRangeItem) {
+      borderStyle.borderBottomRightRadius = borderRadius;
+      borderStyle.borderTopRightRadius = borderRadius;
+    }
+
+    return borderStyle;
   };
 
   private getComponentStyle = (source: StyleType) => {

--- a/src/components/ui/calendar/components/picker/calendarPickerCell.component.tsx
+++ b/src/components/ui/calendar/components/picker/calendarPickerCell.component.tsx
@@ -27,6 +27,7 @@ export interface CalendarPickerCellProps<D> extends StyledComponentProps, Toucha
   range?: boolean;
   firstRangeItem?: boolean;
   lastRangeItem?: boolean;
+  oneDayRange?: boolean;
   onSelect?: (date: CalendarDateInfo<D>) => void;
   children: ChildrenProp<D>;
   shouldComponentUpdate?: (props: CalendarPickerCellProps<D>, nextProps: CalendarPickerCellProps<D>) => boolean;
@@ -49,8 +50,13 @@ export class CalendarPickerCell<D> extends React.Component<CalendarPickerCellPro
   };
 
   private getContainerBorderRadius = (borderRadius: number): StyleType => {
-    const { firstRangeItem, lastRangeItem } = this.props;
+    const { firstRangeItem, lastRangeItem, oneDayRange } = this.props;
 
+    if (oneDayRange) {
+      return {
+        borderRadius,
+      };
+    }
     if (firstRangeItem) {
       return {
         borderBottomLeftRadius: borderRadius,

--- a/src/components/ui/calendar/rangeCalendar.component.tsx
+++ b/src/components/ui/calendar/rangeCalendar.component.tsx
@@ -145,15 +145,13 @@ export class RangeCalendar<D = Date> extends BaseCalendarComponent<RangeCalendar
     const rangeChanged: boolean = props.range !== nextProps.range;
     const rangeStartPlaceChanged: boolean = props.firstRangeItem !== nextProps.firstRangeItem;
     const rangeEndPlaceChanged: boolean = props.lastRangeItem !== nextProps.lastRangeItem;
-    const rangeOneDayDurationChanged: boolean = props.oneDayRange !== nextProps.oneDayRange;
 
     const shouldUpdate: boolean =
       selectionChanged
       || disablingChanged
       || rangeChanged
       || rangeStartPlaceChanged
-      || rangeEndPlaceChanged
-      || rangeOneDayDurationChanged;
+      || rangeEndPlaceChanged;
 
     if (shouldUpdate) {
       return true;

--- a/src/components/ui/calendar/rangeCalendar.component.tsx
+++ b/src/components/ui/calendar/rangeCalendar.component.tsx
@@ -73,7 +73,7 @@ export type RangeCalendarElement<D = Date> = React.ReactElement<RangeCalendarPro
  * @property {(D, NamedStyles) => ReactElement} renderYear - Function component
  * to render instead of default year cell.
  * Called with a date for this cell and styles provided by Eva.
- * 
+ *
  * @property {(D, CalendarViewMode) => void} onVisibleDateChange - Called when navigating to the previous or next month / year.
  * viewMode returns string with current calendar view ("YEAR", "MONTH", "DATE").
  *
@@ -145,13 +145,15 @@ export class RangeCalendar<D = Date> extends BaseCalendarComponent<RangeCalendar
     const rangeChanged: boolean = props.range !== nextProps.range;
     const rangeStartPlaceChanged: boolean = props.firstRangeItem !== nextProps.firstRangeItem;
     const rangeEndPlaceChanged: boolean = props.lastRangeItem !== nextProps.lastRangeItem;
+    const rangeOneDayDurationChanged: boolean = props.oneDayRange !== nextProps.oneDayRange;
 
     const shouldUpdate: boolean =
       selectionChanged
       || disablingChanged
       || rangeChanged
       || rangeStartPlaceChanged
-      || rangeEndPlaceChanged;
+      || rangeEndPlaceChanged
+      || rangeOneDayDurationChanged;
 
     if (shouldUpdate) {
       return true;

--- a/src/components/ui/calendar/service/calendarData.service.ts
+++ b/src/components/ui/calendar/service/calendarData.service.ts
@@ -13,12 +13,13 @@ import {
   CalendarDateInfo,
   CalendarDateOptions,
   CalendarRange,
+  RangeRole,
 } from '../type';
 
 const DEFAULT_DATE_OPTIONS: CalendarDateOptions = {
   bounding: false,
   holiday: false,
-  range: false,
+  range: RangeRole.none,
 };
 
 export type DateRange<D> = CalendarDateInfo<D>[];
@@ -112,7 +113,7 @@ export class CalendarDataService<D> {
   private withRangedStartDates(days: DateRange<D>, startDate): DateRange<D> {
     return days.map((day: CalendarDateInfo<D>): CalendarDateInfo<D> => {
       const isSameStartDate: boolean = this.dateService.compareDatesSafe(day.date, startDate) === 0;
-      return isSameStartDate ? { ...day, range: true } : day;
+      return isSameStartDate ? { ...day, range: RangeRole.start } : day;
     });
   }
 
@@ -120,17 +121,21 @@ export class CalendarDataService<D> {
     return days.map((day: CalendarDateInfo<D>): CalendarDateInfo<D> => {
       const isSameStartDate: boolean = this.dateService.compareDatesSafe(day.date, startDate) === 0;
       const isSameEndDate: boolean = this.dateService.compareDatesSafe(day.date, endDate) === 0;
+      const isInRange: boolean = this.dateService.isBetween(day.date, startDate, endDate);
 
-      if (isSameStartDate || isSameEndDate) {
-        if (isSameStartDate && isSameEndDate) {
-          return { ...day, range: true, oneDayRange: true };
-        } else {
-          return { ...day, range: true };
-        }
+      let rangeRole = RangeRole.none;
+      if (isInRange) {
+        rangeRole = RangeRole.member;
       } else {
-        const isInRange: boolean = this.dateService.isBetween(day.date, startDate, endDate);
-        return { ...day, range: isInRange };
+        if (isSameStartDate) {
+          rangeRole |= RangeRole.start;
+        }
+        if (isSameEndDate) {
+          rangeRole |= RangeRole.end;
+        }
       }
+
+      return { ...day, range: rangeRole };
     });
   }
 

--- a/src/components/ui/calendar/service/calendarData.service.ts
+++ b/src/components/ui/calendar/service/calendarData.service.ts
@@ -122,7 +122,11 @@ export class CalendarDataService<D> {
       const isSameEndDate: boolean = this.dateService.compareDatesSafe(day.date, endDate) === 0;
 
       if (isSameStartDate || isSameEndDate) {
-        return { ...day, range: true };
+        if (isSameStartDate && isSameEndDate) {
+          return { ...day, range: true, oneDayRange: true };
+        } else {
+          return { ...day, range: true };
+        }
       } else {
         const isInRange: boolean = this.dateService.isBetween(day.date, startDate, endDate);
         return { ...day, range: isInRange };

--- a/src/components/ui/calendar/service/rangeDate.service.spec.ts
+++ b/src/components/ui/calendar/service/rangeDate.service.spec.ts
@@ -38,6 +38,16 @@ describe('@range service checks', () => {
     expect(range).toStrictEqual({ startDate, endDate });
   });
 
+  it('* should create range with same start and end dates after select', () => {
+    const startDate = new Date(2019, 8, 12);
+    const endDate = new Date(2019, 8, 12);
+
+    let range: CalendarRange<Date> = rangeService.createRange(initialRange, startDate);
+    range = rangeService.createRange(range, endDate);
+
+    expect(range).toStrictEqual({ startDate, endDate });
+  });
+
   it('* should create range with start date after re-select', () => {
     const startDate = new Date(2019, 8, 12);
     const endDate = new Date(2019, 8, 24);

--- a/src/components/ui/calendar/service/rangeDate.service.ts
+++ b/src/components/ui/calendar/service/rangeDate.service.ts
@@ -30,11 +30,14 @@ export class RangeDateService<D> {
 
   private createRangeForStart(range: CalendarRange<D>, date: D): CalendarRange<D> {
     if (this.dateService.compareDatesSafe(date, range.startDate) === 1) {
+      // startDate > date
       return { startDate: range.startDate, endDate: date };
     } else if (this.dateService.compareDatesSafe(date, range.startDate) === -1) {
+      // startDate < date
       return { startDate: date, endDate: range.startDate };
     } else {
-      return range;
+      // startDate === date, range duration is equal one day
+      return { startDate: range.startDate, endDate: date };
     }
   }
 

--- a/src/components/ui/calendar/service/rangeDate.service.ts
+++ b/src/components/ui/calendar/service/rangeDate.service.ts
@@ -29,15 +29,12 @@ export class RangeDateService<D> {
   }
 
   private createRangeForStart(range: CalendarRange<D>, date: D): CalendarRange<D> {
-    if (this.dateService.compareDatesSafe(date, range.startDate) === 1) {
-      // startDate > date
-      return { startDate: range.startDate, endDate: date };
-    } else if (this.dateService.compareDatesSafe(date, range.startDate) === -1) {
+    if (this.dateService.compareDatesSafe(date, range.startDate) === -1) {
       // startDate < date
       return { startDate: date, endDate: range.startDate };
     } else {
-      // startDate === date, range duration is equal one day
-      return { startDate: range.startDate, endDate: date };
+      // startDate >= date
+      return { startDate: range.startDate ?? date, endDate: date };
     }
   }
 

--- a/src/components/ui/calendar/type.ts
+++ b/src/components/ui/calendar/type.ts
@@ -4,11 +4,18 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  */
 
+export enum RangeRole {
+  none ,
+  member ,
+  start = 1 << 1,
+  end = 2 << 1,
+  complete = start | end,
+}
+
 export interface CalendarDateOptions {
   bounding: boolean;
   holiday: boolean;
-  range?: boolean;
-  oneDayRange?: boolean;
+  range?: RangeRole;
 }
 
 export interface CalendarRange<D> {

--- a/src/components/ui/calendar/type.ts
+++ b/src/components/ui/calendar/type.ts
@@ -8,6 +8,7 @@ export interface CalendarDateOptions {
   bounding: boolean;
   holiday: boolean;
   range?: boolean;
+  oneDayRange?: boolean;
 }
 
 export interface CalendarRange<D> {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
allow to pick one day as completed range, closes #1564
