### PR TITLE
fix(input): fixed double tab for Input component for react-native-web

### DIFF
--- a/src/components/devsupport/components/touchableWithoutFeedback.component.tsx
+++ b/src/components/devsupport/components/touchableWithoutFeedback.component.tsx
@@ -16,6 +16,7 @@ import {
 export interface TouchableWithoutFeedbackProps extends TouchableOpacityProps {
   useDefaultHitSlop?: boolean;
   children?: React.ReactNode;
+  focusable?: boolean;
 }
 
 export type TouchableWithoutFeedbackElement = React.ReactElement<TouchableWithoutFeedbackProps>;

--- a/src/components/ui/input/input.component.tsx
+++ b/src/components/ui/input/input.component.tsx
@@ -263,6 +263,7 @@ export class Input extends React.Component<InputProps> implements WebEventRespon
       <TouchableWithoutFeedback
         testID={testID}
         style={evaStyle.container}
+        focusable={false}
         onPress={this.focus}>
         <FalsyText
           style={[evaStyle.label, styles.label]}
@@ -288,8 +289,8 @@ export class Input extends React.Component<InputProps> implements WebEventRespon
             component={accessoryRight}
           />
         </View>
-        <FalsyText 
-          style={[evaStyle.captionLabel, styles.captionLabel]} 
+        <FalsyText
+          style={[evaStyle.captionLabel, styles.captionLabel]}
           component={caption}
         />
       </TouchableWithoutFeedback>


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
 Removes outline and fix for double tab keyboard behaviour for Input component when used in web, closes #1422 