### PR TITLE
docs: getting started guide, malformed json example (#1605)

### DIFF
--- a/docs/src/articles/guides/getting-started.md
+++ b/docs/src/articles/guides/getting-started.md
@@ -58,7 +58,7 @@ npm i @ui-kitten/components @eva-design/eva react-native-svg
 
 <div class="note note-warning">
   <div class="note-body">
-    If you use Expo for Web, you need to add the following underneath the `"web"` key in `app.json` `"build": { "babel": { "include": [ "@ui-kitten/components" ] }`
+    If you use Expo for Web, you need to add the following underneath the `"web"` key in `app.json` `"build": { "babel": { "include": [ "@ui-kitten/components" ] } }`
   </div>
 </div>
 


### PR DESCRIPTION
docs: getting started guide, malformed json example (#1605)

Fixes #1605 Added missing bracket to JSON example within Getting Started > Manual Installation guide

### Please read and mark the following check list before creating a pull request:

 - [X] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [X] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
Adds a missing bracket to the app.json web configuration example within the "Getting Started" > "Manual Installation" guide.