### PR TITLE
fix autocomplete showcases - pick the wrong item onSelect

### DIFF
--- a/src/showcases/components/autocomplete/autocompleteAccessories.component.tsx
+++ b/src/showcases/components/autocomplete/autocompleteAccessories.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import { TouchableWithoutFeedback } from 'react-native';
 import { Autocomplete, AutocompleteItem, Icon } from '@ui-kitten/components';
 
@@ -21,14 +21,14 @@ export const AutocompleteAccessoriesShowcase = () => {
   const [value, setValue] = React.useState(null);
   const [data, setData] = React.useState(movies);
 
-  const onSelect = (index) => {
+  const onSelect = useCallback((index) => {
     setValue(data[index].title);
-  };
+  }, [data]);
 
-  const onChangeText = (query) => {
+  const onChangeText = useCallback((query) => {
     setValue(query);
     setData(movies.filter(item => filter(item, query)));
-  };
+  }, [movies]);
 
   const clearInput = () => {
     setValue('');

--- a/src/showcases/components/autocomplete/autocompleteAccessories.component.tsx
+++ b/src/showcases/components/autocomplete/autocompleteAccessories.component.tsx
@@ -28,7 +28,7 @@ export const AutocompleteAccessoriesShowcase = () => {
   const onChangeText = useCallback((query) => {
     setValue(query);
     setData(movies.filter(item => filter(item, query)));
-  }, [movies]);
+  }, []);
 
   const clearInput = () => {
     setValue('');

--- a/src/showcases/components/autocomplete/autocompleteHandleKeyboard.component.tsx
+++ b/src/showcases/components/autocomplete/autocompleteHandleKeyboard.component.tsx
@@ -50,7 +50,7 @@ export const AutocompleteHandleKeyboardShowcase = () => {
   const onChangeText = useCallback((query) => {
     setValue(query);
     setData(movies.filter(item => filter(item, query)));
-  }, [movies]);
+  }, []);
 
   const renderOption = (item, index) => (
     <AutocompleteItem

--- a/src/showcases/components/autocomplete/autocompleteHandleKeyboard.component.tsx
+++ b/src/showcases/components/autocomplete/autocompleteHandleKeyboard.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Keyboard, Platform } from 'react-native';
 import { Autocomplete, AutocompleteItem } from '@ui-kitten/components';
 
@@ -43,14 +43,14 @@ export const AutocompleteHandleKeyboardShowcase = () => {
     };
   });
 
-  const onSelect = (index) => {
-    setValue(movies[index].title);
-  };
+  const onSelect = useCallback((index) => {
+    setValue(data[index].title);
+  }, [data]);
 
-  const onChangeText = (query) => {
+  const onChangeText = useCallback((query) => {
     setValue(query);
     setData(movies.filter(item => filter(item, query)));
-  };
+  }, [movies]);
 
   const renderOption = (item, index) => (
     <AutocompleteItem

--- a/src/showcases/components/autocomplete/autocompleteSimpleUsage.component.tsx
+++ b/src/showcases/components/autocomplete/autocompleteSimpleUsage.component.tsx
@@ -23,7 +23,7 @@ export const AutocompleteSimpleUsageShowcase = () => {
   const onChangeText = useCallback((query) => {
     setValue(query);
     setData(movies.filter(item => filter(item, query)));
-  }, [movies]);
+  }, []);
 
   const renderOption = (item, index) => (
     <AutocompleteItem

--- a/src/showcases/components/autocomplete/autocompleteSimpleUsage.component.tsx
+++ b/src/showcases/components/autocomplete/autocompleteSimpleUsage.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Autocomplete, AutocompleteItem } from '@ui-kitten/components';
 
 const movies = [
@@ -16,14 +16,14 @@ export const AutocompleteSimpleUsageShowcase = () => {
   const [value, setValue] = React.useState(null);
   const [data, setData] = React.useState(movies);
 
-  const onSelect = (index) => {
-    setValue(movies[index].title);
-  };
+  const onSelect = useCallback((index) => {
+    setValue(data[index].title);
+  }, [data]);
 
-  const onChangeText = (query) => {
+  const onChangeText = useCallback((query) => {
     setValue(query);
     setData(movies.filter(item => filter(item, query)));
-  };
+  }, [movies]);
 
   const renderOption = (item, index) => (
     <AutocompleteItem


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
 Autocomplete Simple Usage and Autocomplete Handle Keyboard examples pick the wrong item onSelect
 Issue: [1628](https://github.com/akveo/react-native-ui-kitten/issues/1628)