### PR TITLE
fixed: #1648

### DIFF
--- a/src/components/devsupport/components/measure/measure.component.tsx
+++ b/src/components/devsupport/components/measure/measure.component.tsx
@@ -70,9 +70,9 @@ export const MeasureElement: React.FC<MeasureElementProps> = (props): MeasuringE
     props.onMeasure(frame);
   };
 
-  const measureSelf = (): void => {
-    const node: number = findNodeHandle(ref.current);
-    UIManager.measureInWindow(node, onUIManagerMeasure);
+  const measureSelf = (event): void => {
+    const {x,y,width,height} = event.nativeEvent.layout
+    onUIManagerMeasure(x,y,width,height)
   };
 
   if (props.force) {


### PR DESCRIPTION
### Short description of what this resolves: 
bug: when project start ,the menu can't be according, because of the `UIManager.measureInWindow` is deprecated