### PR TITLE
iOS Select component spacing issue fixed.

### DIFF
--- a/src/components/ui/select/select.component.tsx
+++ b/src/components/ui/select/select.component.tsx
@@ -523,6 +523,7 @@ const styles = StyleSheet.create({
   },
   popover: {
     overflow: 'hidden',
+    marginTop: Platform.OS === 'ios' ? -45 : 0,
   },
   list: {
     flexGrow: 0,


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [.] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [.] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves: This was a issue regarding Select Component having inconsistent behaviours on android and iOS platform. The select component worked perfectly fine on android platform but on iOS counterpart it had some extra spacing issue when the selection list was in opened state. I had previously raised a issue for the same, but didn't get any response for the same. Here is the issue link:- https://github.com/akveo/react-native-ui-kitten/issues/1592