### PR TITLE
fix: changed tab indicator position to relative, adjusted bottom nav …

### DIFF
--- a/src/components/ui/bottomNavigation/bottomNavigation.component.tsx
+++ b/src/components/ui/bottomNavigation/bottomNavigation.component.tsx
@@ -192,16 +192,16 @@ export class BottomNavigation extends React.Component<BottomNavigationProps> {
   };
 
   public render(): React.ReactElement<ViewProps> {
-    const { eva, style, ...viewProps } = this.props;
+    const { eva, style, testID } = this.props;
     const evaStyle = this.getComponentStyle(eva.style);
     const [indicatorElement, ...tabElements] = this.renderComponentChildren(evaStyle);
 
     return (
-      <View
-        {...viewProps}
-        style={[evaStyle.container, styles.container, style]}>
+      <View testID={testID} style={styles.container}>
         {indicatorElement}
-        {tabElements}
+        <View style={[ evaStyle.container, styles.elementsContainer, style ]}>
+          {tabElements}
+        </View>
       </View>
     );
   }
@@ -209,6 +209,9 @@ export class BottomNavigation extends React.Component<BottomNavigationProps> {
 
 const styles = StyleSheet.create({
   container: {
+    flexGrow: 1,
+  },
+  elementsContainer: {
     flexDirection: 'row',
   },
   item: {

--- a/src/components/ui/shared/tabIndicator.component.tsx
+++ b/src/components/ui/shared/tabIndicator.component.tsx
@@ -108,7 +108,6 @@ export class TabIndicator extends React.Component<TabIndicatorProps> {
 
     return {
       width: `${widthPercent}%`,
-      position: 'absolute',
 
       // @ts-ignore: RN has no types for `Animated` styles
       transform: [ { translateX: this.contentOffset } ],


### PR DESCRIPTION
…bar layout

### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
 On of our previous updates let user to apply their own style to tab indicator, however it broke indicator positioning for tab bar. It was displayed on top. There is corresponding opened issue: #1656