### PR TITLE
fix: added frame check for popover state update

### DIFF
--- a/src/components/ui/popover/popover.component.tsx
+++ b/src/components/ui/popover/popover.component.tsx
@@ -172,7 +172,9 @@ export class Popover extends React.Component<PopoverProps, State> {
   }
 
   private onChildMeasure = (childFrame: Frame): void => {
-    this.setState({ childFrame });
+    if (!childFrame.equals(this.state.childFrame)) {
+      this.setState({ childFrame });
+    }
 
     if (!this.modalId && this.props.visible) {
       this.show();
@@ -185,7 +187,9 @@ export class Popover extends React.Component<PopoverProps, State> {
   };
 
   private onContentMeasure = (anchorFrame: Frame): void => {
-    this.setState({ anchorFrame });
+    if (!anchorFrame.equals(this.state.anchorFrame)) {
+      this.setState({ anchorFrame });
+    }
 
     const placementOptions: PlacementOptions = this.findPlacementOptions(anchorFrame, this.state.childFrame);
     this.actualPlacement = this.placementService.find(this.preferredPlacement, placementOptions);


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:
 This PR fixes `Popover` component issue related to infinite re-render loop. That's how the issue works: popover's content is visible and after first update content is set to be forced measured. `MeasureElement` measure itself and return new `Frame` object to `Popover` component. `Popover` sets this new object to its state (`childFrame`). State update causes re-render, which causes `MeasureElement` to measure it again (as it is forced to measure itself each render) and pass new `Frame` object to be set to `Popover`'s state. I've added frame check - if it's the same frame we won't update the state.
 
 This one fixed lots of failing tests:
 
 before 
 
![image](https://user-images.githubusercontent.com/7077915/199977974-5785e382-fcd1-4f34-bd5a-5201bd6b075d.png)

 after
 
![image (1)](https://user-images.githubusercontent.com/7077915/199978046-5cd87dad-3562-4944-8f86-1c36018f4301.png)

