### PR TITLE
Fix Popover render issue in Android

### DIFF
--- a/src/components/ui/autocomplete/autocomplete.component.tsx
+++ b/src/components/ui/autocomplete/autocomplete.component.tsx
@@ -256,6 +256,8 @@ const styles = StyleSheet.create({
     maxHeight: 192,
     overflow: 'hidden',
     borderWidth: 0,
+    // this is here to fix the component's popover misplacement in Android
+    marginBottom: -1 * (react_native_1.StatusBar.currentHeight || 0),
   },
   list: {
     flexGrow: 0,


### PR DESCRIPTION
In Android specifically, the popover is rendered incorrectly cause the it is ignoring the hight of the StatusBar, this small change would fix the issue

### Please read and mark the following check list before creating a pull request:

 - [] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves: