### PR TITLE
fix: add transformIgnorePatterns to templates

### DIFF
--- a/src/template-js/template/package.json
+++ b/src/template-js/template/package.json
@@ -29,6 +29,9 @@
     "react-test-renderer": "18.1.0"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "react-native",
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@ui-kitten)"
+    ]
   }
 }

--- a/src/template-ts/template/package.json
+++ b/src/template-ts/template/package.json
@@ -45,6 +45,9 @@
       "jsx",
       "json",
       "node"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@ui-kitten)"
     ]
   }
 }


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Test are failing in the templates. Adding `transformIgnorePatterns` and adding `@ui-kitten` fixes this.

Full regex from: https://docs.expo.dev/develop/unit-testing/#configuration