### PR TITLE
Fix for issues #1782 & #1767

### DIFF
--- a/src/components/devsupport/components/measure/measure.component.tsx
+++ b/src/components/devsupport/components/measure/measure.component.tsx
@@ -56,8 +56,8 @@ export const MeasureElement: React.FC<MeasureElementProps> = (props): MeasuringE
     const boundFrame: Frame = new Frame(
       frame.origin.x - window.size.width,
       frame.origin.y,
-      Math.round(frame.size.width),
-      Math.round(frame.size.height),
+      Math.floor(frame.size.width),
+      Math.floor(frame.size.height),
     );
 
     return bindToWindow(boundFrame, window);
@@ -68,7 +68,7 @@ export const MeasureElement: React.FC<MeasureElementProps> = (props): MeasuringE
       measureSelf();
     } else {
       const originY = props.shouldUseTopInsets ? y + StatusBar.currentHeight || 0 : y;
-      const frame: Frame = bindToWindow(new Frame(x, originY, Math.round(w), Math.round(h)), Frame.window());
+      const frame: Frame = bindToWindow(new Frame(x, originY, Math.floor(w), Math.floor(h)), Frame.window());
       props.onMeasure(frame);
     }
   };


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

 - [x] I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.
 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Issue #1767 is about modal flickering, it is caused by assigning decimal dimensions on modals, the fix just adds a Math.round() to width and height for Frames.

Issue #1782 is about a crash happening only on iOS when UI Kitten tries to measure a node that RN did not find, Android seems to support it but it makes an iOS app crash.