### PR TITLE
Prevent crash if UI manager isn't ready yet.

### DIFF
--- a/src/components/devsupport/components/measure/measure.component.tsx
+++ b/src/components/devsupport/components/measure/measure.component.tsx
@@ -74,8 +74,14 @@ export const MeasureElement: React.FC<MeasureElementProps> = (props): MeasuringE
   };
 
   const measureSelf = (): void => {
-    const node: number = findNodeHandle(ref.current);
-    UIManager.measureInWindow(node, onUIManagerMeasure);
+    try {
+      const node: number = findNodeHandle(ref.current);
+      UIManager.measureInWindow(node, onUIManagerMeasure);
+    } catch (error) {
+      // measureInWindow can throw an exception if the UI manager isn't read yet.
+      // Try again with a short delay
+      setTimeout(measureSelf, 100);
+    }
   };
 
   if (props.force) {


### PR DESCRIPTION
### Please read and mark the following check list before creating a pull request:

- [x]  I read and followed the [CONTRIBUTING.md](https://github.com/akveo/react-native-ui-kitten/blob/master/CONTRIBUTING.md) guide.

 - [x] I read and followed the [New Feature Checklist](https://github.com/akveo/react-native-ui-kitten/blob/master/DEV_DOCS.md) guide.

 #### Short description of what this resolves:

Calling `UIManager.measureInWindow` can throw an exception and crash the app if the UIManager isn't defined yet (see `nullthrows` in the [react native code](https://github.com/facebook/react-native/blob/v0.72.6/packages/react-native/Libraries/ReactNative/UIManager.js#L88)). I have not been able to reproduce this directly, but have been getting a handful of app crash reports per day that point to this (see stack trace below).

My proposed solution is to catch the exception and then try again after a short delay. The delay is to prevent a possible infinite loop slowing down the app.

 #### Stack trace

```
Error Got unexpected undefined 
    Users/runner/work/together/together/packages/dating-app/node_modules/nullthrows/nullthrows.js:7:23 nullthrows
    Users/runner/work/together/together/packages/dating-app/node_modules/react-native/Libraries/ReactNative/UIManager.js:88:40 measureInWindow
    Users/runner/work/together/together/packages/dating-app/node_modules/@ui-kitten/components/devsupport/components/measure/measure.component.js:60:48 measureSelf
    Users/runner/work/together/together/packages/dating-app/node_modules/@ui-kitten/components/devsupport/components/measure/measure.component.js:50:23 onUIManagerMeasure
    (native) apply
    Users/runner/work/together/together/packages/dating-app/node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:474:12 __invokeCallback
    Users/runner/work/together/together/packages/dating-app/node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:124:27 anonymous
    Users/runner/work/together/together/packages/dating-app/node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:368:10 __guard
    Users/runner/work/together/together/packages/dating-app/node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:123:16 invokeCallbackAndReturnFlushedQueue
```