### PR TITLE
Update LiteralUnion type definition so it doesnt cast everything to string

### DIFF
--- a/src/components/devsupport/typings.ts
+++ b/src/components/devsupport/typings.ts
@@ -8,7 +8,7 @@ export type ChildrenWithProps<Props> = ChildrenProp<ReactElement<Props>>;
  * https://github.com/microsoft/TypeScript/issues/29729#issuecomment-505826972
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type LiteralUnion<T extends U, U = string> = T | (U & {});
+export type LiteralUnion<T extends U, U = string> = T | (string & {});
 
 export type EvaStatus = LiteralUnion<'basic' | 'primary' | 'success' | 'info' | 'warning' | 'danger' | 'control'>;
 export type EvaSize = LiteralUnion<'tiny' | 'small' | 'medium' | 'large' | 'giant'>;


### PR DESCRIPTION
If LiteralUnion is defined like this:

```
export type LiteralUnion<T extends U, U = string> = T | (U & {});
```

It will make these have string type:

```
EvaStatus
EvaSize
EvaInputSize
```

So information about union is lost.

This is possible fix:

```
export type LiteralUnion<T extends U, U = string> = T | (string & {});
```

Now EvaSize and other will be of proper union type, and they will also allow custom string.

This fix will also make autocomplete possible for those props.